### PR TITLE
Admin app bootstrap: dashboard fix, scripts cleanup, pf-db tool

### DIFF
--- a/docs/scripts_user_guide.md
+++ b/docs/scripts_user_guide.md
@@ -7,14 +7,18 @@ Operational scripts for developing, debugging, and managing the Industry Night p
 | Script | Purpose | Key flags |
 |--------|---------|-----------|
 | `deploy-api.sh` | Build & deploy API to EKS | `--skip-build`, `--status` |
+| `pf-db.sh` | DB tunnel: localhost:5432 → db-proxy → RDS | `start`, `stop`, `status` |
 | `db-reset.js` | Full DB reset + migrations | `--skip-k8s`, `--seed-only`, `--yes` |
 | `db-scrub-user.js` | Delete users by phone | `--skip-k8s`, `--yes` |
+| `seed-admin.js` | Create or reset an admin user | `--skip-k8s` |
 | `maintenance.sh` | ALB maintenance mode toggle | `on`, `off`, `status` |
 | `setup-local.sh` | Init local dev environment | (none) |
 | `run-api.sh` | Start API dev server | (none) |
-| `run-mobile.sh` | Start mobile app | (none) |
-| `run-web.sh` | Start web admin | (none) |
+| `run-mobile.sh` | Start **social app** on simulator/device | (none) |
+| `run-web.sh` | Start **admin app** in Chrome | (none) |
 | `debug-api.sh` | Remote Node.js debugging on EKS | `enable`, `disable` |
+| `generate-exec-brief.py` | Regenerate PowerPoint executive brief | (none) |
+| `generate-exec-summary.py` | Regenerate markdown executive summary | (none) |
 
 ---
 
@@ -41,7 +45,7 @@ Starts the Express API server in development mode (`npm run dev`).
 
 ### run-mobile.sh
 
-Starts the Flutter mobile app. Requires a connected device or running simulator/emulator.
+Starts the Flutter **social app** (iOS/Android) on a connected simulator or device.
 
 ```bash
 open -a Simulator          # Start iOS Simulator first
@@ -50,7 +54,7 @@ open -a Simulator          # Start iOS Simulator first
 
 ### run-web.sh
 
-Starts the Flutter web admin dashboard on Chrome at port 8080.
+Starts the Flutter **admin app** in Chrome at port 8080. Connects to `https://api.industrynight.net` (production API) — no local API or DB tunnel required.
 
 ```bash
 ./scripts/run-web.sh
@@ -63,10 +67,10 @@ Starts the Flutter web admin dashboard on Chrome at port 8080.
 # Terminal 1
 ./scripts/run-api.sh
 
-# Terminal 2
+# Terminal 2 — social app
 ./scripts/run-mobile.sh
 
-# Terminal 3 (if working on web admin)
+# Terminal 3 — admin app (web)
 ./scripts/run-web.sh
 ```
 
@@ -105,6 +109,39 @@ Toggles maintenance mode at the ALB level. When enabled, the ALB returns a 503 J
 ---
 
 ## Database
+
+### pf-db.sh
+
+Opens and closes the kubectl port-forward tunnel to the RDS database via the `db-proxy` pod. Use this when you need a persistent DB connection for ad-hoc work — running `psql`, resetting admin credentials with `seed-admin.js`, etc.
+
+```bash
+./scripts/pf-db.sh start    # Open tunnel: localhost:5432 → db-proxy → RDS
+./scripts/pf-db.sh stop     # Close tunnel and free port 5432
+./scripts/pf-db.sh status   # Is the tunnel open?
+```
+
+**Note:** `db-reset.js`, `db-scrub-user.js`, and `seed-admin.js` all manage their own port-forward internally — you do not need to run `pf-db.sh` before those scripts.
+
+### seed-admin.js
+
+Creates or resets an admin user in the `admin_users` table. Uses upsert — running it again with the same email updates the password and name without creating a duplicate.
+
+```bash
+# With EKS running (auto-manages port-forward)
+DB_PASSWORD=xxx node scripts/seed-admin.js \
+  --email admin@industrynight.net \
+  --name "Admin" \
+  --password <yourpassword>
+
+# Local PostgreSQL only (no k8s tunnel)
+DB_PASSWORD=xxx node scripts/seed-admin.js \
+  --email admin@industrynight.net \
+  --name "Admin" \
+  --password <yourpassword> \
+  --skip-k8s
+```
+
+**Requires:** `DB_PASSWORD` env var. Auto-starts `kubectl port-forward` to `db-proxy` unless `--skip-k8s`.
 
 ### db-reset.js
 
@@ -185,7 +222,56 @@ Enables remote Node.js debugging on the EKS API pod. Scales to 1 replica, inject
 
 ---
 
+## Reporting
+
+### generate-exec-brief.py
+
+Regenerates the 13-slide PowerPoint executive brief at `docs/Industry Night - Executive Brief.pptx`. Dark theme, purple accents, widescreen (16:9).
+
+```bash
+python3 -m venv /tmp/pptx-env && source /tmp/pptx-env/bin/activate && pip install python-pptx
+python3 scripts/generate-exec-brief.py
+```
+
+Edit data values directly in the script before regenerating — see CLAUDE.md for which fields to update for a weekly brief.
+
+### generate-exec-summary.py
+
+Regenerates the companion markdown executive summary at `docs/executive-brief.md`.
+
+```bash
+python3 scripts/generate-exec-summary.py
+```
+
+---
+
 ## Common Workflows
+
+### Launch the admin app locally
+
+The admin app talks to the production API (`https://api.industrynight.net`) — no local API or DB tunnel needed.
+
+```bash
+./scripts/run-web.sh
+# Opens at http://localhost:8080
+```
+
+### Set up admin credentials, then launch the admin app
+
+```bash
+# 1. Set your DB password (from AWS Secrets Manager or your notes)
+export DB_PASSWORD=xxx
+
+# 2. Create or reset the admin user (script manages port-forward automatically)
+node scripts/seed-admin.js \
+  --email admin@industrynight.net \
+  --name "Admin" \
+  --password <yourpassword>
+
+# 3. Launch the admin app
+./scripts/run-web.sh
+# Login at http://localhost:8080 with the credentials above
+```
 
 ### Deploy a backend fix
 
@@ -214,4 +300,13 @@ DB_PASSWORD=xxx node scripts/db-reset.js
 # Attach VS Code debugger, reproduce the issue, inspect state
 # Ctrl+C when done
 ./scripts/debug-api.sh disable
+```
+
+### Ad-hoc database access (psql or other tools)
+
+```bash
+./scripts/pf-db.sh start
+psql -h localhost -U industrynight -d industrynight
+# ... do your work ...
+./scripts/pf-db.sh stop
 ```

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -23,12 +23,12 @@ router.get('/dashboard', async (_req, res, next) => {
       total_posts: number;
     }>(`
       SELECT
-        (SELECT COUNT(*) FROM users WHERE banned = false) as total_users,
-        (SELECT COUNT(*) FROM users WHERE verification_status = 'verified') as verified_users,
-        (SELECT COUNT(*) FROM events) as total_events,
-        (SELECT COUNT(*) FROM events WHERE start_time > NOW() AND status = 'published') as upcoming_events,
-        (SELECT COUNT(*) FROM connections) as total_connections,
-        (SELECT COUNT(*) FROM posts WHERE is_hidden = false) as total_posts
+        (SELECT COUNT(*) FROM users WHERE banned = false)::int as total_users,
+        (SELECT COUNT(*) FROM users WHERE verification_status = 'verified')::int as verified_users,
+        (SELECT COUNT(*) FROM events)::int as total_events,
+        (SELECT COUNT(*) FROM events WHERE start_time > NOW() AND status = 'published')::int as upcoming_events,
+        (SELECT COUNT(*) FROM connections)::int as total_connections,
+        (SELECT COUNT(*) FROM posts WHERE is_hidden = false)::int as total_posts
     `);
 
     res.json({ stats });

--- a/scripts/pf-db.sh
+++ b/scripts/pf-db.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+#
+# pf-db.sh — Manage kubectl port-forward tunnel to RDS via the db-proxy pod
+#
+# WHY THIS EXISTS:
+#   Database admin scripts (db-reset.js, db-scrub-user.js, seed-admin.js) each
+#   manage their own port-forward internally. But for ad-hoc work — running psql,
+#   resetting admin credentials, inspecting data — you need a persistent tunnel
+#   without running a full script.
+#
+#   This script starts, stops, and checks that tunnel.
+#
+# HOW IT WORKS:
+#   The db-proxy pod runs socat, forwarding TCP to the RDS endpoint on port 5432.
+#   kubectl port-forward creates a local tunnel: localhost:5432 → pod:5432 → RDS.
+#
+# USAGE:
+#   ./scripts/pf-db.sh start    # Open tunnel (runs in background)
+#   ./scripts/pf-db.sh stop     # Close tunnel
+#   ./scripts/pf-db.sh status   # Is the tunnel open?
+#
+
+NAMESPACE="industrynight"
+AWS_PROFILE="industrynight-admin"
+LOCAL_PORT=5432
+PID_FILE="/tmp/industrynight-pf-db.pid"
+
+case "$1" in
+  start)
+    # Kill anything already occupying the port
+    lsof -ti :$LOCAL_PORT 2>/dev/null | xargs kill 2>/dev/null || true
+    sleep 1
+
+    echo "Starting port-forward: localhost:$LOCAL_PORT → db-proxy → RDS..."
+    AWS_PROFILE=$AWS_PROFILE kubectl port-forward pod/db-proxy $LOCAL_PORT:5432 \
+      -n $NAMESPACE &>/dev/null &
+    PF_PID=$!
+    echo $PF_PID > "$PID_FILE"
+
+    # Wait for port to become reachable (up to 15s)
+    attempts=0
+    while ! nc -z localhost $LOCAL_PORT 2>/dev/null; do
+      sleep 1
+      attempts=$((attempts + 1))
+      if [[ $attempts -ge 15 ]]; then
+        echo "Error: tunnel did not become ready after 15s"
+        echo "Check that the EKS cluster is running and db-proxy pod exists:"
+        echo "  AWS_PROFILE=$AWS_PROFILE kubectl get pod/db-proxy -n $NAMESPACE"
+        kill $PF_PID 2>/dev/null
+        rm -f "$PID_FILE"
+        exit 1
+      fi
+    done
+
+    echo "Tunnel ready (PID $PF_PID)"
+    echo ""
+    echo "  localhost:$LOCAL_PORT → RDS"
+    echo ""
+    echo "Run './scripts/pf-db.sh stop' when done."
+    ;;
+
+  stop)
+    if [[ -f "$PID_FILE" ]]; then
+      PF_PID=$(cat "$PID_FILE")
+      kill "$PF_PID" 2>/dev/null \
+        && echo "Stopped port-forward (PID $PF_PID)" \
+        || echo "Process $PF_PID already gone"
+      rm -f "$PID_FILE"
+    fi
+    # Also catch any strays
+    pkill -f "port-forward.*db-proxy" 2>/dev/null || true
+    lsof -ti :$LOCAL_PORT 2>/dev/null | xargs kill 2>/dev/null || true
+    echo "Port $LOCAL_PORT is free."
+    ;;
+
+  status)
+    if nc -z localhost $LOCAL_PORT 2>/dev/null; then
+      if [[ -f "$PID_FILE" ]]; then
+        PF_PID=$(cat "$PID_FILE")
+        echo "OPEN  localhost:$LOCAL_PORT → RDS  (PID $PF_PID)"
+      else
+        echo "OPEN  localhost:$LOCAL_PORT → RDS  (PID unknown — started externally)"
+      fi
+    else
+      echo "CLOSED  (nothing listening on localhost:$LOCAL_PORT)"
+    fi
+    ;;
+
+  *)
+    echo "Usage: $0 {start|stop|status}"
+    echo ""
+    echo "  start    Open tunnel: localhost:$LOCAL_PORT → db-proxy → RDS"
+    echo "  stop     Close tunnel and free port $LOCAL_PORT"
+    echo "  status   Check whether the tunnel is open"
+    exit 1
+    ;;
+esac

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -49,7 +49,7 @@ async function main() {
     host: process.env.DB_HOST || 'localhost',
     port: parseInt(process.env.DB_PORT || '5432'),
     database: process.env.DB_NAME || 'industrynight',
-    user: process.env.DB_USER || 'postgres',
+    user: process.env.DB_USER || 'industrynight',
     password: process.env.DB_PASSWORD || undefined,
     ssl: skipK8s ? false : { rejectUnauthorized: false },
   });


### PR DESCRIPTION
## Summary

- **Fix admin dashboard crash** — `COUNT(*)` in PostgreSQL returns `bigint`, which the `pg` library serializes as a string. Added `::int` cast to all counts in `/admin/dashboard`, fixing the \"Failed to load dashboard data\" error on first login
- **Fix `seed-admin.js` DB user default** — was defaulting to `postgres` instead of `industrynight`, causing auth failure when running against RDS without explicitly setting `DB_USER`
- **Add `scripts/pf-db.sh`** — standalone `start`/`stop`/`status` script for the kubectl port-forward tunnel to RDS via `db-proxy`. Useful for pgAdmin, psql, and other ad-hoc DB tools without running a full DB script
- **Refresh `docs/scripts_user_guide.md`** — added `pf-db.sh`, `seed-admin.js`, and exec brief scripts to the quick reference; clarified `run-mobile.sh` (social app) vs `run-web.sh` (admin app) naming; added admin app launch and credential setup workflows

## Test plan

- [ ] `node scripts/seed-admin.js --email ... --password ...` connects successfully without setting `DB_USER`
- [ ] `./scripts/pf-db.sh start` opens tunnel, `status` shows OPEN, `stop` closes it
- [ ] pgAdmin connects via localhost:5432 while tunnel is open
- [ ] Admin app dashboard loads without error after login
- [ ] `./scripts/run-web.sh` and `./scripts/run-mobile.sh` descriptions match reality

🤖 Generated with [Claude Code](https://claude.com/claude-code)