### PR TITLE
COOP housekeeping + multi-env + API URL config

### DIFF
--- a/packages/admin-app/lib/providers/admin_state.dart
+++ b/packages/admin-app/lib/providers/admin_state.dart
@@ -15,7 +15,7 @@ class AdminState extends ChangeNotifier {
     ApiClient? apiClient,
     SecureStorage? storage,
   })  : _apiClient = apiClient ??
-            ApiClient(baseUrl: apiBaseUrl ?? 'https://api.industrynight.net'),
+            ApiClient(baseUrl: apiBaseUrl ?? AppConfig.apiBaseUrl),
         _storage = storage ?? SecureStorage() {
     _apiClient.onTokenExpired = _refreshAccessToken;
   }

--- a/packages/shared/lib/config/app_config.dart
+++ b/packages/shared/lib/config/app_config.dart
@@ -1,0 +1,12 @@
+/// Compile-time configuration passed via --dart-define.
+///
+/// Defaults are dev-safe. Production values are injected by deploy scripts.
+///
+/// Usage:
+///   flutter run --dart-define=API_BASE_URL=https://api.industrynight.net
+class AppConfig {
+  static const String apiBaseUrl = String.fromEnvironment(
+    'API_BASE_URL',
+    defaultValue: 'https://dev-api.industrynight.net',
+  );
+}

--- a/packages/shared/lib/shared.dart
+++ b/packages/shared/lib/shared.dart
@@ -30,6 +30,9 @@ export 'api/admin_api.dart';
 export 'constants/specialties.dart';
 export 'constants/verification_status.dart';
 
+// Config
+export 'config/app_config.dart';
+
 // Utils
 export 'utils/validators.dart';
 export 'utils/formatters.dart';

--- a/packages/social-app/lib/providers/app_state.dart
+++ b/packages/social-app/lib/providers/app_state.dart
@@ -21,7 +21,7 @@ class AppState extends ChangeNotifier {
     ApiClient? apiClient,
     SecureStorage? storage,
   })  : _apiClient = apiClient ??
-            ApiClient(baseUrl: apiBaseUrl ?? 'https://api.industrynight.net'),
+            ApiClient(baseUrl: apiBaseUrl ?? AppConfig.apiBaseUrl),
         _storage = storage ?? SecureStorage() {
     // Wire up automatic token refresh on 401 responses
     _apiClient.onTokenExpired = _refreshAccessToken;

--- a/scripts/run-admin-app.sh
+++ b/scripts/run-admin-app.sh
@@ -1,16 +1,38 @@
 #!/bin/bash
 
 # Start admin app in development mode (Chrome)
+# Usage: ./scripts/run-admin-app.sh [--env dev|prod]
 
 cd "$(dirname "$0")/../packages/admin-app"
 
+# Default to dev API
+API_URL="https://dev-api.industrynight.net"
+
+# Parse --env flag
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --env)
+      if [ "$2" = "prod" ]; then
+        API_URL="https://api.industrynight.net"
+        echo "** Using PRODUCTION API **"
+      fi
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 echo "Starting Industry Night Admin App..."
+echo "API: $API_URL"
 echo "App will be available at http://localhost:8080"
 
+DART_DEFINES="--dart-define=API_BASE_URL=$API_URL"
+
 # Pass Google Places API key if set in environment
-DART_DEFINES=""
 if [ -n "$GOOGLE_PLACES_API_KEY" ]; then
-  DART_DEFINES="--dart-define=GOOGLE_PLACES_API_KEY=$GOOGLE_PLACES_API_KEY"
+  DART_DEFINES="$DART_DEFINES --dart-define=GOOGLE_PLACES_API_KEY=$GOOGLE_PLACES_API_KEY"
   echo "Google Places autocomplete: enabled"
 else
   echo "Google Places autocomplete: disabled (set GOOGLE_PLACES_API_KEY to enable)"

--- a/scripts/run-mobile.sh
+++ b/scripts/run-mobile.sh
@@ -1,10 +1,31 @@
 #!/bin/bash
 
 # Start mobile app in development mode
+# Usage: ./scripts/run-mobile.sh [--env dev|prod]
 
 cd "$(dirname "$0")/../packages/social-app"
 
+# Default to dev API
+API_URL="https://dev-api.industrynight.net"
+
+# Parse --env flag
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --env)
+      if [ "$2" = "prod" ]; then
+        API_URL="https://api.industrynight.net"
+        echo "** Using PRODUCTION API **"
+      fi
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
 echo "Starting Industry Night Social App..."
+echo "API: $API_URL"
 echo ""
 
 # Check for connected devices
@@ -20,4 +41,4 @@ if [ "$DEVICES" -eq 0 ]; then
     exit 1
 fi
 
-flutter run
+flutter run --dart-define=API_BASE_URL="$API_URL"


### PR DESCRIPTION
## Summary
- Consolidated schema into single baseline migration, hardened COOP scripts
- Parameterized all infrastructure scripts for `--env dev|prod` (default: dev)
- Fixed dev rebuild: template replica count, removed unnecessary rollout restart
- Added `API_BASE_URL` dart-define support so Flutter apps resolve the correct API per environment (default: dev)

## Test plan
- [ ] `./scripts/coop/coop.sh status` shows dev environment status
- [ ] `flutter run` from admin-app or social-app hits `dev-api.industrynight.net` by default
- [ ] `./scripts/run-admin-app.sh --env prod` hits `api.industrynight.net`
- [ ] `./scripts/deploy-admin.sh --env dev` injects correct dev API URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)