### PR TITLE
feat: harden posh RSVP/check-in flow across API and apps

### DIFF
--- a/docs/guides/manual_audit_security_test_checklist.md
+++ b/docs/guides/manual_audit_security_test_checklist.md
@@ -1,0 +1,66 @@
+# Manual Audit Security Test Checklist (Dev)
+
+Purpose: track manual security test actions and verify corresponding audit_log rows.
+
+## Test Session
+- Date: 2026-03-17
+- Environment: dev
+- API host: https://dev-api.industrynight.net
+- Tester: Jeff
+
+## How To Use
+1. Execute one manual action at a time.
+2. Mark status as In Progress, Pass, or Fail.
+3. Verify expected audit_log fields.
+4. Add notes for mismatches or missing rows.
+
+## Expected Core Fields For All Security Events
+- action
+- entity_type
+- result
+- failure_reason (for failures)
+- route
+- method
+- status_code
+- occurred_at
+- request_id
+- metadata
+
+## Manual Scenarios
+
+| ID | Scenario | Endpoint | Expected result | Expected failure_reason | Manual status | Audit status | Notes |
+|---|---|---|---|---|---|---|---|
+| M-01 | Bad phone format on request code | POST /auth/request-code | failure | validation failure (currently gap to capture in audit) | In Progress | Pending | Validation middleware path |
+| M-02 | Provider/Twilio send failure on request code | POST /auth/request-code | failure | request_code_failed | Pass | Pass | Confirmed in audit_log |
+| M-03 | Wrong verification code (correct phone) | POST /auth/verify-code | failure | invalid_verification_code | Pass | Pass | Confirmed in audit_log |
+| M-04 | Expired verification code | POST /auth/verify-code | failure | verification_code_expired | Pass | Retest Pending | Initially logged as verify_code_failed, classification patch deployed; confirm on next run |
+| M-05 | Bad admin email | POST /admin/auth/login | failure | admin_not_found | Pending | Pending | Manual run pending |
+| M-06 | Bad admin password | POST /admin/auth/login | failure | invalid_credentials | Pending | Pending | Manual run pending |
+| M-07 | Missing auth header on protected social route | GET /auth/me | failure | missing_authorization_header | Pending | Pending | Manual/API tool trigger |
+| M-08 | Wrong token family on social route | GET /auth/me | failure | token_family_mismatch | Pending | Pending | Manual/API tool trigger |
+| M-09 | Wrong token family on admin route | GET /admin/dashboard | failure | token_family_mismatch | Pending | Pending | Manual/API tool trigger |
+| M-10 | Invalid webhook signature | POST /webhooks/posh | failure | invalid_signature | Pending | Pending | Manual script/curl |
+| M-11 | Malformed webhook payload | POST /webhooks/posh | failure | malformed_payload | Pending | Pending | Manual script/curl |
+
+## Known Gaps
+- Validation middleware failures (for example malformed phone input) are not yet explicitly audited as security events.
+- Provider-specific Twilio error categorization is not yet normalized beyond request_code_failed.
+
+## Verification Query Pattern
+Use focused filters by route and time window to avoid mixing with unrelated failures.
+
+Example columns to inspect:
+- occurred_at
+- action
+- entity_type
+- result
+- failure_reason
+- route
+- method
+- status_code
+- metadata
+
+## Session Notes
+- M-02 confirmed: request_code_failed row present for /auth/request-code.
+- M-03 confirmed: invalid_verification_code row present for /auth/verify-code.
+- M-04 observed: expired attempt logged as verify_code_failed before patch; patch deployed and awaiting re-validation.

--- a/docs/guides/manual_audit_security_test_checklist.md
+++ b/docs/guides/manual_audit_security_test_checklist.md
@@ -30,20 +30,19 @@ Purpose: track manual security test actions and verify corresponding audit_log r
 
 | ID | Scenario | Endpoint | Expected result | Expected failure_reason | Manual status | Audit status | Notes |
 |---|---|---|---|---|---|---|---|
-| M-01 | Bad phone format on request code | POST /auth/request-code | failure | validation failure (currently gap to capture in audit) | In Progress | Pending | Validation middleware path |
+| M-01 | Bad phone format on request code | POST /auth/request-code | failure | validation_failed | Pass | Pass | request_id `e0ba9e9e-73f6-4ea7-82dc-33981f7f8b46` |
 | M-02 | Provider/Twilio send failure on request code | POST /auth/request-code | failure | request_code_failed | Pass | Pass | Confirmed in audit_log |
 | M-03 | Wrong verification code (correct phone) | POST /auth/verify-code | failure | invalid_verification_code | Pass | Pass | Confirmed in audit_log |
-| M-04 | Expired verification code | POST /auth/verify-code | failure | verification_code_expired | Pass | Retest Pending | Initially logged as verify_code_failed, classification patch deployed; confirm on next run |
-| M-05 | Bad admin email | POST /admin/auth/login | failure | admin_not_found | Pending | Pending | Manual run pending |
-| M-06 | Bad admin password | POST /admin/auth/login | failure | invalid_credentials | Pending | Pending | Manual run pending |
-| M-07 | Missing auth header on protected social route | GET /auth/me | failure | missing_authorization_header | Pending | Pending | Manual/API tool trigger |
-| M-08 | Wrong token family on social route | GET /auth/me | failure | token_family_mismatch | Pending | Pending | Manual/API tool trigger |
-| M-09 | Wrong token family on admin route | GET /admin/dashboard | failure | token_family_mismatch | Pending | Pending | Manual/API tool trigger |
-| M-10 | Invalid webhook signature | POST /webhooks/posh | failure | invalid_signature | Pending | Pending | Manual script/curl |
-| M-11 | Malformed webhook payload | POST /webhooks/posh | failure | malformed_payload | Pending | Pending | Manual script/curl |
+| M-04 | Expired verification code | POST /auth/verify-code | failure | verification_code_expired | Pass | Pass | request_id `fc0d7b4c-d7b9-4181-92f5-13fc5f50d753` |
+| M-05 | Bad admin email | POST /admin/auth/login | failure | admin_not_found | Pass | Pass | request_id `b2ad9807-e8a8-445a-91c3-07d7090c8612` |
+| M-06 | Bad admin password | POST /admin/auth/login | failure | invalid_credentials | Pass | Pass | request_id `5a6dd938-846c-4607-9976-1d5afb5ad870` |
+| M-07 | Missing auth header on protected social route | GET /auth/me | failure | missing_authorization_header | Pass | Pass | request_id `26605148-6423-4358-9541-f85df44296f9` |
+| M-08 | Wrong token family on social route | GET /auth/me | failure | token_family_mismatch | Pass | Pass | request_id `2e4fe347-9fc0-43fd-8dab-2de5fb9e2943` |
+| M-09 | Wrong token family on admin route | GET /admin/dashboard | failure | token_family_mismatch | Pass | Pass | request_id `d9c6ea6f-d6bd-4a77-b41a-55e833983aea` |
+| M-10 | Invalid webhook signature | POST /webhooks/posh | failure | invalid_signature | Pass | Pass | request_id `539672ed-4dff-4738-9633-77ae03c491a3` |
+| M-11 | Malformed webhook payload | POST /webhooks/posh | failure | malformed_payload | Pass | Pass | request_id `0555bc2a-d835-408d-b1e2-661bc6bfb016` |
 
 ## Known Gaps
-- Validation middleware failures (for example malformed phone input) are not yet explicitly audited as security events.
 - Provider-specific Twilio error categorization is not yet normalized beyond request_code_failed.
 
 ## Verification Query Pattern
@@ -63,4 +62,8 @@ Example columns to inspect:
 ## Session Notes
 - M-02 confirmed: request_code_failed row present for /auth/request-code.
 - M-03 confirmed: invalid_verification_code row present for /auth/verify-code.
-- M-04 observed: expired attempt logged as verify_code_failed before patch; patch deployed and awaiting re-validation.
+- M-04 revalidated: expired attempt now logs `verification_code_expired`.
+- M-01 revalidated: validation middleware logs `validation_failed` end-to-end in dev.
+- M-05 through M-09 validated with matching failure reasons and request-level audit rows.
+- Webhook negative tests now pass after wiring `POSH_WEBHOOK_SECRET` into the dev k8s secret and redeploying.
+- Webhook handler now classifies malformed payloads as `malformed_payload` instead of falling through to `webhook_processing_failed`.

--- a/docs/product/implementation_plan.md
+++ b/docs/product/implementation_plan.md
@@ -306,6 +306,16 @@ This document outlines the implementation plan for the Industry Night platform, 
 - [ ] Posh API sync (automatic event import)
 - [ ] Android release
 
+### Phase 4: Infrastructure Scaling (Post-Revenue)
+- [ ] **Migrate prod RDS PostgreSQL → Aurora Serverless v2 (PostgreSQL-compatible)**
+  - Production only — dev stays on RDS PostgreSQL (simpler, cheaper at dev scale)
+  - Aurora Serverless v2 scales instantly between min/max ACUs based on load, eliminating idle cost during off-hours
+  - Continuous backup to S3 at 1-second granularity (vs daily snapshots on RDS)
+  - ~30s failover vs 1-2 min on RDS; up to 15 read replicas if needed
+  - Migration path: snapshot RDS → restore into Aurora cluster → update connection string → verify
+  - Defer until real load patterns exist to right-size min/max ACU settings
+- [ ] Upgrade EKS node group if API load warrants it (currently t3.small)
+
 ---
 
 ## Mobile App Screen Inventory

--- a/infrastructure/k8s/deployment.yaml
+++ b/infrastructure/k8s/deployment.yaml
@@ -28,6 +28,8 @@ spec:
           env:
             - name: NODE_ENV
               value: "production"
+            - name: AUDIT_ENVIRONMENT
+              value: "__ENVIRONMENT__"
             - name: PORT
               value: "3000"
             - name: AWS_REGION

--- a/packages/admin-app/lib/features/events/screens/event_detail_screen.dart
+++ b/packages/admin-app/lib/features/events/screens/event_detail_screen.dart
@@ -126,6 +126,7 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
   /// file_picker package silently fails to open on Flutter Web.
   Future<Uint8List?> _pickImageBytes() async {
     final completer = Completer<Uint8List?>();
+    var fileSelectionStarted = false;
 
     final input = html.FileUploadInputElement()..accept = 'image/*';
     html.document.body!.children.add(input);
@@ -137,6 +138,8 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
         if (!completer.isCompleted) completer.complete(null);
         return;
       }
+
+      fileSelectionStarted = true;
       final reader = html.FileReader()..readAsArrayBuffer(files[0]);
       reader.onLoad.listen((_) {
         if (!completer.isCompleted) {
@@ -149,11 +152,14 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
     });
 
     // onFocus fires when the file dialog closes (cancel or selection). Use
-    // a 1000ms delay so onChange always wins when a file was chosen — Chrome
-    // fires focus before change in some versions.
+    // a 1000ms delay and only auto-cancel when no file selection started.
+    // Chrome can fire focus before change; if a file was selected, FileReader
+    // may still be loading bytes after focus returns.
     html.window.onFocus.first.then((_) {
       Future.delayed(const Duration(milliseconds: 1000), () {
-        if (!completer.isCompleted) completer.complete(null);
+        if (!completer.isCompleted && !fileSelectionStarted) {
+          completer.complete(null);
+        }
       });
     });
 
@@ -396,6 +402,12 @@ class _InfoCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final e = event;
+    final poshUrl = e.poshEventUrl?.trim();
+    final hasPoshUrl = poshUrl != null && poshUrl.isNotEmpty;
+    final normalizedPoshUrl = hasPoshUrl && !poshUrl.contains('://')
+        ? 'https://$poshUrl'
+        : poshUrl;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(24),
@@ -422,6 +434,14 @@ class _InfoCard extends StatelessWidget {
               _InfoRow(Icons.people, 'Capacity: ${e.capacity}'),
             if (e.poshEventId != null)
               _InfoRow(Icons.confirmation_number, 'Posh ID: ${e.poshEventId}'),
+            _InfoRow(
+              Icons.link,
+              hasPoshUrl ? 'Posh URL: $normalizedPoshUrl' : 'Posh URL: Not Set',
+              onTap: hasPoshUrl
+                  ? () => html.window.open(normalizedPoshUrl!, '_blank')
+                  : null,
+              emphasize: !hasPoshUrl,
+            ),
             if (e.description != null && e.description!.isNotEmpty) ...[
               const SizedBox(height: 16),
               Text('Description', style: Theme.of(context).textTheme.labelMedium),
@@ -438,11 +458,22 @@ class _InfoCard extends StatelessWidget {
 class _InfoRow extends StatelessWidget {
   final IconData icon;
   final String text;
+  final VoidCallback? onTap;
+  final bool emphasize;
 
-  const _InfoRow(this.icon, this.text);
+  const _InfoRow(this.icon, this.text, {this.onTap, this.emphasize = false});
 
   @override
   Widget build(BuildContext context) {
+    final linkStyle = TextStyle(
+      color: Theme.of(context).colorScheme.primary,
+      decoration: TextDecoration.underline,
+    );
+    final alertStyle = TextStyle(
+      color: Theme.of(context).colorScheme.error,
+      fontWeight: FontWeight.w600,
+    );
+
     return Padding(
       padding: const EdgeInsets.symmetric(vertical: 6),
       child: Row(
@@ -450,7 +481,14 @@ class _InfoRow extends StatelessWidget {
         children: [
           Icon(icon, size: 18, color: Theme.of(context).hintColor),
           const SizedBox(width: 10),
-          Expanded(child: Text(text)),
+          Expanded(
+            child: onTap != null
+                ? InkWell(
+                    onTap: onTap,
+                    child: Text(text, style: linkStyle),
+                  )
+                : Text(text, style: emphasize ? alertStyle : null),
+          ),
         ],
       ),
     );

--- a/packages/admin-app/lib/features/events/screens/event_form_screen.dart
+++ b/packages/admin-app/lib/features/events/screens/event_form_screen.dart
@@ -27,8 +27,10 @@ class _EventFormScreenState extends State<EventFormScreen> {
   final _descriptionController = TextEditingController();
   final _capacityController    = TextEditingController();
   final _poshEventIdController = TextEditingController();
+  final _poshEventUrlController = TextEditingController();
 
   DateTime? _startDate;
+  DateTime? _endDate;
   TimeOfDay? _startTime;
   TimeOfDay? _endTime;
   bool _isSubmitting = false;
@@ -49,7 +51,9 @@ class _EventFormScreenState extends State<EventFormScreen> {
       _descriptionController.text  = e.description ?? '';
       _capacityController.text     = e.capacity?.toString() ?? '';
       _poshEventIdController.text  = e.poshEventId ?? '';
+      _poshEventUrlController.text = e.poshEventUrl ?? '';
       _startDate = e.startTime;
+      _endDate = e.endTime;
       _startTime = TimeOfDay.fromDateTime(e.startTime);
       _endTime   = TimeOfDay.fromDateTime(e.endTime);
       _selectedMarketId = e.marketId;
@@ -79,6 +83,7 @@ class _EventFormScreenState extends State<EventFormScreen> {
     _descriptionController.dispose();
     _capacityController.dispose();
     _poshEventIdController.dispose();
+    _poshEventUrlController.dispose();
     super.dispose();
   }
 
@@ -99,10 +104,10 @@ class _EventFormScreenState extends State<EventFormScreen> {
     if (!_formKey.currentState!.validate()) return;
 
     final startDateTime = _combineDateTime(_startDate, _startTime);
-    final endDateTime   = _combineDateTime(_startDate, _endTime);
+    final endDateTime   = _combineDateTime(_endDate, _endTime);
 
     if (startDateTime == null || endDateTime == null) {
-      _showError('Please select date, start time, and end time');
+      _showError('Please select start and end dates/times');
       return;
     }
     if (!endDateTime.isAfter(startDateTime)) {
@@ -123,6 +128,7 @@ class _EventFormScreenState extends State<EventFormScreen> {
           description:  _descriptionController.text.trim().isNotEmpty ? _descriptionController.text.trim() : null,
           capacity:     _capacityController.text.trim().isNotEmpty ? int.tryParse(_capacityController.text.trim()) : null,
           poshEventId:  _poshEventIdController.text.trim().isNotEmpty ? _poshEventIdController.text.trim() : null,
+          poshEventUrl: _poshEventUrlController.text.trim().isNotEmpty ? _poshEventUrlController.text.trim() : null,
           startTime:    startDateTime,
           endTime:      endDateTime,
           marketId:     _selectedMarketId,
@@ -142,6 +148,7 @@ class _EventFormScreenState extends State<EventFormScreen> {
           description:  _descriptionController.text.trim().isNotEmpty ? _descriptionController.text.trim() : null,
           capacity:     _capacityController.text.trim().isNotEmpty ? int.tryParse(_capacityController.text.trim()) : null,
           poshEventId:  _poshEventIdController.text.trim().isNotEmpty ? _poshEventIdController.text.trim() : null,
+          poshEventUrl: _poshEventUrlController.text.trim().isNotEmpty ? _poshEventUrlController.text.trim() : null,
           marketId:     _selectedMarketId,
         );
         if (!mounted) return;
@@ -241,7 +248,7 @@ class _EventFormScreenState extends State<EventFormScreen> {
                     Row(
                       children: [
                         Expanded(child: _DateTile(
-                          label: 'Date *',
+                          label: 'Start Date *',
                           value: _startDate != null
                               ? DateFormat('MMM d, yyyy').format(_startDate!)
                               : null,
@@ -263,7 +270,42 @@ class _EventFormScreenState extends State<EventFormScreen> {
                               firstDate: firstDate,
                               lastDate: lastDate,
                             );
-                            if (d != null) setState(() => _startDate = d);
+                            if (d != null) {
+                              setState(() {
+                                _startDate = d;
+                                _endDate ??= d;
+                                if (_endDate!.isBefore(d)) {
+                                  _endDate = d;
+                                }
+                              });
+                            }
+                          },
+                        )),
+                        const SizedBox(width: 16),
+                        Expanded(child: _DateTile(
+                          label: 'End Date *',
+                          value: _endDate != null
+                              ? DateFormat('MMM d, yyyy').format(_endDate!)
+                              : null,
+                          onTap: () async {
+                            final now = DateTime.now();
+                            final fallbackFirstDate = _dateOnly(now).subtract(const Duration(days: 1));
+                            final lastDate = _dateOnly(now).add(const Duration(days: 730));
+                            final firstDate = _startDate != null
+                                ? _dateOnly(_startDate!)
+                                : fallbackFirstDate;
+                            final initialDate = _clampDate(
+                              _dateOnly(_endDate ?? _startDate ?? now.add(const Duration(days: 7))),
+                              firstDate,
+                              lastDate,
+                            );
+                            final d = await showDatePicker(
+                              context: context,
+                              initialDate: initialDate,
+                              firstDate: firstDate,
+                              lastDate: lastDate,
+                            );
+                            if (d != null) setState(() => _endDate = d);
                           },
                         )),
                       ],
@@ -318,7 +360,18 @@ class _EventFormScreenState extends State<EventFormScreen> {
                       decoration: const InputDecoration(
                         labelText: 'Posh Event ID',
                         hintText: 'Find this in your Posh event URL',
-                        helperText: 'Required before publishing. From your Posh event URL or dashboard.',
+                        helperText: 'Required before publishing. Used for webhook order matching.',
+                      ),
+                    ),
+                    const SizedBox(height: 16),
+
+                    // Posh event URL
+                    TextFormField(
+                      controller: _poshEventUrlController,
+                      decoration: const InputDecoration(
+                        labelText: 'Posh Event URL',
+                        hintText: 'https://posh.vip/e/your-event',
+                        helperText: 'Optional canonical URL for reference and reconciliation.',
                       ),
                     ),
                     const SizedBox(height: 32),

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -41,6 +41,10 @@ app.use(cors({
 }));
 app.use(compression());
 app.use(requestContext);
+
+// Webhooks must receive the raw body for signature verification.
+app.use('/webhooks', webhooksRoutes);
+
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 
@@ -115,7 +119,6 @@ app.use('/posts', postsRoutes);
 app.use('/sponsors', sponsorsRoutes);
 app.use('/vendors', vendorsRoutes);
 app.use('/discounts', discountsRoutes);
-app.use('/webhooks', webhooksRoutes);
 app.use('/admin/auth', adminAuthLimiter, adminAuthRoutes);
 app.use('/admin', adminRoutes);
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -7,6 +7,7 @@ import rateLimit from 'express-rate-limit';
 import { config } from './config/env';
 import { errorHandler } from './utils/errors';
 import pool, { query } from './config/database';
+import { requestContext } from './middleware/request-context';
 
 // Routes
 import authRoutes from './routes/auth';
@@ -23,6 +24,15 @@ import adminAuthRoutes from './routes/admin-auth';
 
 const app = express();
 
+if (!config.audit.enabled && config.nodeEnv !== 'test') {
+  console.error('');
+  console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+  console.error('!! SECURITY WARNING: AUDIT LOGGING IS DISABLED          !!');
+  console.error('!! Set AUDIT_ENABLED=true before production startup.     !!');
+  console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');
+  console.error('');
+}
+
 // Middleware
 app.use(helmet());
 app.use(cors({
@@ -30,6 +40,7 @@ app.use(cors({
   credentials: true,
 }));
 app.use(compression());
+app.use(requestContext);
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -36,6 +36,11 @@ const envSchema = z.object({
   // Posh
   POSH_WEBHOOK_SECRET: z.string().optional(),
 
+  // Audit
+  AUDIT_ENABLED: z.string().default('true'),
+  AUDIT_METADATA_VERSION: z.string().default('1'),
+  AUDIT_ENVIRONMENT: z.enum(['development', 'production', 'test']).optional(),
+
   // CORS
   CORS_ORIGINS: z.string().default('http://localhost:3000,http://localhost:8080'),
 });
@@ -83,6 +88,12 @@ export const config = {
 
   posh: {
     webhookSecret: env.data.POSH_WEBHOOK_SECRET,
+  },
+
+  audit: {
+    enabled: env.data.AUDIT_ENABLED === 'true',
+    metadataVersion: parseInt(env.data.AUDIT_METADATA_VERSION, 10),
+    environment: env.data.AUDIT_ENVIRONMENT ?? env.data.NODE_ENV,
   },
 
   corsOrigins: env.data.CORS_ORIGINS.split(','),

--- a/packages/api/src/config/env.ts
+++ b/packages/api/src/config/env.ts
@@ -35,6 +35,7 @@ const envSchema = z.object({
 
   // Posh
   POSH_WEBHOOK_SECRET: z.string().optional(),
+  POSH_WEBHOOK_COMPAT_MODE: z.string().default('false'),
 
   // Audit
   AUDIT_ENABLED: z.string().default('true'),
@@ -88,6 +89,7 @@ export const config = {
 
   posh: {
     webhookSecret: env.data.POSH_WEBHOOK_SECRET,
+    webhookCompatMode: env.data.POSH_WEBHOOK_COMPAT_MODE === 'true',
   },
 
   audit: {

--- a/packages/api/src/middleware/admin-auth.ts
+++ b/packages/api/src/middleware/admin-auth.ts
@@ -1,11 +1,30 @@
 import { Request, Response, NextFunction } from 'express';
 import { verifyToken } from '../config/auth';
 import { UnauthorizedError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
-export function authenticateAdmin(req: Request, _res: Response, next: NextFunction) {
+function classifyTokenError(error: unknown): string {
+  if (error && typeof error === 'object' && 'name' in error) {
+    const name = String((error as { name?: unknown }).name);
+    if (name === 'TokenExpiredError') return 'token_expired';
+    if (name === 'JsonWebTokenError') return 'invalid_token';
+    if (name === 'NotBeforeError') return 'token_not_active';
+  }
+  return 'token_validation_failed';
+}
+
+export async function authenticateAdmin(req: Request, _res: Response, next: NextFunction) {
   try {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'missing_authorization_header',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Missing authorization header');
     }
 
@@ -13,10 +32,30 @@ export function authenticateAdmin(req: Request, _res: Response, next: NextFuncti
     const payload = verifyToken(token);
 
     if (payload.type !== 'access') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_token_type',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Invalid token type');
     }
 
     if (payload.tokenFamily !== 'admin') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'token_family_mismatch',
+        statusCode: 401,
+        metadata: {
+          expectedTokenFamily: 'admin',
+          receivedTokenFamily: payload.tokenFamily ?? 'missing',
+        },
+      });
       throw new UnauthorizedError('Admin access required');
     }
 
@@ -25,8 +64,17 @@ export function authenticateAdmin(req: Request, _res: Response, next: NextFuncti
   } catch (error) {
     if (error instanceof UnauthorizedError) {
       next(error);
-    } else {
-      next(new UnauthorizedError('Invalid or expired token'));
+      return;
     }
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'reject',
+      entityType: 'admin_auth',
+      actorType: 'system',
+      result: 'failure',
+      failureReason: classifyTokenError(error),
+      statusCode: 401,
+    });
+    next(new UnauthorizedError('Invalid or expired token'));
   }
 }

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,19 +1,30 @@
 import { Request, Response, NextFunction } from 'express';
-import { verifyToken, JwtPayload } from '../config/auth';
+import { verifyToken } from '../config/auth';
 import { UnauthorizedError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
-declare global {
-  namespace Express {
-    interface Request {
-      user?: JwtPayload;
-    }
+function classifyTokenError(error: unknown): string {
+  if (error && typeof error === 'object' && 'name' in error) {
+    const name = String((error as { name?: unknown }).name);
+    if (name === 'TokenExpiredError') return 'token_expired';
+    if (name === 'JsonWebTokenError') return 'invalid_token';
+    if (name === 'NotBeforeError') return 'token_not_active';
   }
+  return 'token_validation_failed';
 }
 
-export function authenticate(req: Request, _res: Response, next: NextFunction) {
+export async function authenticate(req: Request, _res: Response, next: NextFunction) {
   try {
     const authHeader = req.headers.authorization;
     if (!authHeader?.startsWith('Bearer ')) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'missing_authorization_header',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Missing authorization header');
     }
 
@@ -21,12 +32,49 @@ export function authenticate(req: Request, _res: Response, next: NextFunction) {
     const payload = verifyToken(token);
 
     if (payload.type !== 'access') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_token_type',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Invalid token type');
+    }
+
+    if (payload.tokenFamily !== 'social') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'token_family_mismatch',
+        statusCode: 401,
+        metadata: {
+          expectedTokenFamily: 'social',
+          receivedTokenFamily: payload.tokenFamily ?? 'missing',
+        },
+      });
+      throw new UnauthorizedError('Invalid token family');
     }
 
     req.user = payload;
     next();
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      next(error);
+      return;
+    }
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'reject',
+      entityType: 'auth',
+      actorType: 'system',
+      result: 'failure',
+      failureReason: classifyTokenError(error),
+      statusCode: 401,
+    });
     next(new UnauthorizedError('Invalid or expired token'));
   }
 }

--- a/packages/api/src/middleware/request-context.ts
+++ b/packages/api/src/middleware/request-context.ts
@@ -1,0 +1,12 @@
+import { randomUUID } from 'crypto';
+import { Request, Response, NextFunction } from 'express';
+
+export function requestContext(req: Request, res: Response, next: NextFunction) {
+  const incomingRequestId = req.header('x-request-id')?.trim();
+  const requestId = incomingRequestId || randomUUID();
+
+  req.requestId = requestId;
+  res.setHeader('x-request-id', requestId);
+
+  next();
+}

--- a/packages/api/src/middleware/validation.ts
+++ b/packages/api/src/middleware/validation.ts
@@ -1,9 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { z, ZodSchema } from 'zod';
 import { BadRequestError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 export function validate(schema: ZodSchema) {
-  return (req: Request, _res: Response, next: NextFunction) => {
+  return async (req: Request, _res: Response, next: NextFunction) => {
     try {
       const parsed = schema.parse({
         body: req.body,
@@ -23,6 +24,21 @@ export function validate(schema: ZodSchema) {
           if (!errors[path]) errors[path] = [];
           errors[path].push(err.message);
         });
+
+        await tryLogSecurityEventFromRequest(req, {
+          action: 'reject',
+          entityType: 'validation',
+          actorType: req.user ? 'user' : 'system',
+          actorId: req.user?.userId,
+          result: 'failure',
+          failureReason: 'validation_failed',
+          statusCode: 400,
+          metadata: {
+            errorCount: error.errors.length,
+            errorPaths: Object.keys(errors).slice(0, 10),
+          },
+        });
+
         next(new BadRequestError('Validation failed', errors));
       } else {
         next(error);

--- a/packages/api/src/routes/admin-auth.ts
+++ b/packages/api/src/routes/admin-auth.ts
@@ -1,13 +1,19 @@
 import { Router } from 'express';
 import bcrypt from 'bcryptjs';
+import crypto from 'crypto';
 import { z } from 'zod';
 import { validate } from '../middleware/validation';
 import { authenticateAdmin } from '../middleware/admin-auth';
 import { verifyToken, generateAdminTokenPair } from '../config/auth';
 import { queryOne } from '../config/database';
 import { UnauthorizedError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
+
+function hashEmail(email: string): string {
+  return crypto.createHash('sha256').update(email.toLowerCase()).digest('hex');
+}
 
 // Login
 const loginSchema = z.object({
@@ -33,11 +39,33 @@ router.post('/login', validate(loginSchema), async (req, res, next): Promise<voi
     }>('SELECT * FROM admin_users WHERE email = $1', [email.toLowerCase()]);
 
     if (!admin || !admin.is_active) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: !admin ? 'admin_not_found' : 'admin_inactive',
+        statusCode: 401,
+        metadata: {
+          emailHash: hashEmail(email),
+        },
+      });
       throw new UnauthorizedError('Invalid credentials');
     }
 
     const validPassword = await bcrypt.compare(password, admin.password_hash);
     if (!validPassword) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_credentials',
+        statusCode: 401,
+        metadata: {
+          emailHash: hashEmail(email),
+        },
+      });
       throw new UnauthorizedError('Invalid credentials');
     }
 
@@ -48,6 +76,15 @@ router.post('/login', validate(loginSchema), async (req, res, next): Promise<voi
     );
 
     const tokens = generateAdminTokenPair(admin.id, admin.role);
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'admin_auth',
+      actorType: 'admin',
+      adminActorId: admin.id,
+      result: 'success',
+      statusCode: 200,
+    });
 
     res.json({
       accessToken: tokens.accessToken,
@@ -81,6 +118,14 @@ router.post('/refresh', validate(refreshSchema), async (req, res, next): Promise
     const payload = verifyToken(refreshToken);
 
     if (payload.type !== 'refresh' || payload.tokenFamily !== 'admin') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_refresh_token',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Invalid refresh token');
     }
 
@@ -95,10 +140,30 @@ router.post('/refresh', validate(refreshSchema), async (req, res, next): Promise
     }>('SELECT * FROM admin_users WHERE id = $1', [payload.userId]);
 
     if (!admin || !admin.is_active) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'admin_auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'admin_not_found_or_inactive',
+        statusCode: 401,
+      });
       throw new UnauthorizedError('Invalid refresh token');
     }
 
     const tokens = generateAdminTokenPair(admin.id, admin.role);
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'admin_auth',
+      actorType: 'admin',
+      adminActorId: admin.id,
+      result: 'success',
+      statusCode: 200,
+      metadata: {
+        flow: 'refresh',
+      },
+    });
 
     res.json({
       accessToken: tokens.accessToken,
@@ -152,7 +217,16 @@ router.get('/me', authenticateAdmin, async (req, res, next): Promise<void> => {
 });
 
 // Logout
-router.post('/logout', authenticateAdmin, (_req, res) => {
+router.post('/logout', authenticateAdmin, async (req, res) => {
+  await tryLogSecurityEventFromRequest(req, {
+    action: 'logout',
+    entityType: 'admin_auth',
+    actorType: 'admin',
+    adminActorId: req.user!.userId,
+    result: 'success',
+    statusCode: 200,
+  });
+
   res.json({ message: 'Logged out' });
 });
 

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -8,6 +8,7 @@ import { query, queryOne } from '../config/database';
 import { generateActivationCode } from '../utils/jwt';
 import { NotFoundError, BadRequestError } from '../utils/errors';
 import { uploadImage, deleteImage } from '../services/storage';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
 
@@ -246,6 +247,17 @@ const updateUserSchema = z.object({
 router.patch('/users/:id', validate(updateUserSchema), async (req, res, next): Promise<void> => {
   try {
     const { role, banned, verificationStatus } = req.body;
+    const existingUser = await queryOne<{
+      id: string;
+      role: string;
+      banned: boolean;
+      verification_status: string;
+    }>(
+      'SELECT id, role, banned, verification_status FROM users WHERE id = $1',
+      [req.params.id]
+    );
+
+    if (!existingUser) throw new NotFoundError('User not found');
 
     const updates: string[] = [];
     const params: unknown[] = [];
@@ -267,12 +279,66 @@ router.patch('/users/:id', validate(updateUserSchema), async (req, res, next): P
     updates.push('updated_at = NOW()');
     params.push(req.params.id);
 
-    const user = await queryOne(
+    const user = await queryOne<any>(
       `UPDATE users SET ${updates.join(', ')} WHERE id = $${paramIndex} RETURNING *`,
       params
     );
 
     if (!user) throw new NotFoundError('User not found');
+
+    const adminActorId = req.user!.userId;
+
+    if (existingUser.role !== user.role) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'update',
+        entityType: 'user',
+        entityId: user.id,
+        actorType: 'admin',
+        adminActorId,
+        result: 'success',
+        statusCode: 200,
+        oldValues: { role: existingUser.role },
+        newValues: { role: user.role },
+        metadata: { field: 'role' },
+      });
+    }
+
+    if (existingUser.banned !== user.banned) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: user.banned ? 'ban' : 'unban',
+        entityType: 'user',
+        entityId: user.id,
+        actorType: 'admin',
+        adminActorId,
+        result: 'success',
+        statusCode: 200,
+        oldValues: { banned: existingUser.banned },
+        newValues: { banned: user.banned },
+        metadata: { field: 'banned' },
+      });
+    }
+
+    if (existingUser.verification_status !== user.verification_status) {
+      const verificationAction =
+        user.verification_status === 'verified'
+          ? 'verify'
+          : user.verification_status === 'rejected'
+            ? 'reject'
+            : 'update';
+
+      await tryLogSecurityEventFromRequest(req, {
+        action: verificationAction,
+        entityType: 'user',
+        entityId: user.id,
+        actorType: 'admin',
+        adminActorId,
+        result: 'success',
+        statusCode: 200,
+        oldValues: { verificationStatus: existingUser.verification_status },
+        newValues: { verificationStatus: user.verification_status },
+        metadata: { field: 'verification_status' },
+      });
+    }
 
     res.json({ user });
   } catch (error) {
@@ -550,11 +616,23 @@ router.patch('/events/:id', validate(updateEventSchema), async (req, res, next):
 
 router.delete('/events/:id', async (req, res, next): Promise<void> => {
   try {
-    const rows = await query('SELECT status FROM events WHERE id = $1', [req.params.id]);
+    const rows = await query<{ status: string }>('SELECT status FROM events WHERE id = $1', [req.params.id]);
     if (rows.length === 0) throw new NotFoundError('Event not found');
-    if ((rows[0] as any).status !== 'draft') {
+    if (rows[0].status !== 'draft') {
       throw new BadRequestError('Only draft events can be deleted');
     }
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'event',
+      entityId: req.params.id,
+      actorType: 'admin',
+      adminActorId: req.user!.userId,
+      result: 'success',
+      statusCode: 200,
+      oldValues: { status: rows[0].status },
+    });
+
     await query('DELETE FROM events WHERE id = $1', [req.params.id]);
     res.json({ message: 'Event deleted' });
   } catch (error) {
@@ -654,6 +732,23 @@ router.delete('/events/:id/images/:imageId', async (req, res, next): Promise<voi
 
     if (!image) throw new NotFoundError('Image not found');
     if (image.event_id !== req.params.id) throw new NotFoundError('Image not found');
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'event_image',
+      entityId: image.id,
+      actorType: 'admin',
+      adminActorId: req.user!.userId,
+      result: 'success',
+      statusCode: 200,
+      oldValues: {
+        eventId: image.event_id,
+        sortOrder: image.sort_order,
+      },
+      metadata: {
+        imageUrl: image.url,
+      },
+    });
 
     await deleteImage(image.url);
     await query('DELETE FROM event_images WHERE id = $1', [req.params.imageId]);
@@ -1285,6 +1380,16 @@ router.delete('/customers/:id', async (req, res, next): Promise<void> => {
   try {
     const customer = await queryOne('SELECT id FROM customers WHERE id = $1', [req.params.id]);
     if (!customer) throw new NotFoundError('Customer not found');
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'customer',
+      entityId: req.params.id,
+      actorType: 'admin',
+      adminActorId: req.user!.userId,
+      result: 'success',
+      statusCode: 200,
+    });
 
     await query('DELETE FROM customers WHERE id = $1', [req.params.id]);
     res.json({ message: 'Customer deleted' });

--- a/packages/api/src/routes/admin.ts
+++ b/packages/api/src/routes/admin.ts
@@ -476,21 +476,22 @@ const createEventSchema = z.object({
     description: z.string().optional(),
     capacity: z.number().positive().optional(),
     poshEventId: z.string().optional(),
+    poshEventUrl: z.string().optional(),
     marketId: z.string().uuid().optional(),
   }),
 });
 
 router.post('/events', validate(createEventSchema), async (req, res, next) => {
   try {
-    const { name, venueName, venueAddress, startTime, endTime, description, capacity, poshEventId, marketId } = req.body;
+    const { name, venueName, venueAddress, startTime, endTime, description, capacity, poshEventId, poshEventUrl, marketId } = req.body;
     const activationCode = generateActivationCode();
 
     const row = await queryOne(
       `INSERT INTO events
-         (name, venue_name, venue_address, start_time, end_time, description, capacity, activation_code, posh_event_id, market_id)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+         (name, venue_name, venue_address, start_time, end_time, description, capacity, activation_code, posh_event_id, posh_event_url, market_id)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
        RETURNING *`,
-      [name, venueName ?? null, venueAddress ?? null, startTime, endTime, description ?? null, capacity ?? null, activationCode, poshEventId ?? null, marketId ?? null]
+      [name, venueName ?? null, venueAddress ?? null, startTime, endTime, description ?? null, capacity ?? null, activationCode, poshEventId ?? null, poshEventUrl ?? null, marketId ?? null]
     );
 
     // Join market name for the response
@@ -520,6 +521,7 @@ const updateEventSchema = z.object({
     startTime: z.string().min(1).optional(),
     endTime: z.string().min(1).optional(),
     poshEventId: z.string().nullable().optional(),
+    poshEventUrl: z.string().nullable().optional(),
     status: z.enum(['draft', 'published', 'cancelled', 'completed']).optional(),
     capacity: z.number().positive().nullable().optional(),
     marketId: z.string().uuid().nullable().optional(),
@@ -528,7 +530,7 @@ const updateEventSchema = z.object({
 
 router.patch('/events/:id', validate(updateEventSchema), async (req, res, next): Promise<void> => {
   try {
-    const { name, description, venueName, venueAddress, startTime, endTime, poshEventId, status, capacity, marketId } = req.body;
+    const { name, description, venueName, venueAddress, startTime, endTime, poshEventId, poshEventUrl, status, capacity, marketId } = req.body;
 
     // Publish gate: verify all requirements before allowing status → published
     if (status === 'published') {
@@ -575,6 +577,7 @@ router.patch('/events/:id', validate(updateEventSchema), async (req, res, next):
     if (startTime    !== undefined) { updates.push(`start_time = $${paramIndex++}`);    params.push(startTime); }
     if (endTime      !== undefined) { updates.push(`end_time = $${paramIndex++}`);      params.push(endTime); }
     if (poshEventId  !== undefined) { updates.push(`posh_event_id = $${paramIndex++}`); params.push(poshEventId); }
+    if (poshEventUrl !== undefined) { updates.push(`posh_event_url = $${paramIndex++}`); params.push(poshEventUrl); }
     if (status       !== undefined) { updates.push(`status = $${paramIndex++}`);        params.push(status); }
     if (capacity     !== undefined) { updates.push(`capacity = $${paramIndex++}`);      params.push(capacity); }
     if (marketId     !== undefined) { updates.push(`market_id = $${paramIndex++}`);     params.push(marketId); }

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -7,6 +7,7 @@ import { query, queryOne } from '../config/database';
 import { verifyAvailable, sendVerification, checkVerification } from '../services/sms';
 import { generateVerificationCode } from '../utils/jwt';
 import { BadRequestError, NotFoundError, UnauthorizedError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
 
@@ -66,7 +67,7 @@ async function reconcilePoshOrdersForUser(userId: string, phone: string): Promis
 
   if (linkedOrders > 0 || createdTickets > 0) {
     console.log(
-      `[AUTH] Reconciled Posh orders for ${phone}: linked=${linkedOrders}, tickets=${createdTickets}, durationMs=${elapsedMs}`
+      `[AUTH] Reconciled Posh orders for ****${phone.slice(-4)}: linked=${linkedOrders}, tickets=${createdTickets}, durationMs=${elapsedMs}`
     );
   }
 
@@ -100,10 +101,33 @@ router.post('/request-code', validate(requestCodeSchema), async (req, res, next)
         [phone, code, expiresAt]
       );
 
-      console.log(`[SMS-DEV] Verification code for ${phone}: ${code}`);
+      console.log(`[SMS-DEV] Verification code generated for ****${phone.slice(-4)}`);
       res.json({ message: 'Verification code sent', devCode: code });
     }
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'system',
+      result: 'success',
+      statusCode: 200,
+      metadata: {
+        flow: 'request_code',
+        provider: verifyAvailable ? 'twilio_verify' : 'local_dev',
+      },
+    });
   } catch (error) {
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'system',
+      result: 'failure',
+      failureReason: 'request_code_failed',
+      statusCode: 400,
+      metadata: {
+        flow: 'request_code',
+      },
+    });
     next(error);
   }
 });
@@ -181,12 +205,46 @@ router.post('/verify-code', validate(verifyCodeSchema), async (req, res, next) =
       [user!.id]
     );
 
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'user',
+      actorId: user!.id,
+      result: 'success',
+      statusCode: 200,
+      metadata: {
+        flow: 'verify_code',
+        isNewUser,
+      },
+    });
+
     res.json({
       ...tokens,
       user: fullUser,
       isNewUser,
     });
   } catch (error) {
+    let failureReason = 'verify_code_failed';
+    if (error instanceof BadRequestError) {
+      const message = error.message.toLowerCase();
+      if (message.includes('expired')) {
+        failureReason = 'verification_code_expired';
+      } else if (message.includes('invalid')) {
+        failureReason = 'invalid_verification_code';
+      }
+    }
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'system',
+      result: 'failure',
+      failureReason,
+      statusCode: 400,
+      metadata: {
+        flow: 'verify_code',
+      },
+    });
     next(error);
   }
 });
@@ -204,6 +262,17 @@ router.post('/refresh', validate(refreshSchema), async (req, res, next) => {
 
     const payload = verifyToken(refreshToken);
     if (payload.type !== 'refresh' || payload.tokenFamily !== 'social') {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_refresh_token',
+        statusCode: 401,
+        metadata: {
+          flow: 'refresh',
+        },
+      });
       throw new UnauthorizedError('Invalid refresh token');
     }
 
@@ -213,23 +282,66 @@ router.post('/refresh', validate(refreshSchema), async (req, res, next) => {
     );
 
     if (!user || user.banned) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'login',
+        entityType: 'auth',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: !user ? 'user_not_found' : 'user_banned',
+        statusCode: 401,
+        metadata: {
+          flow: 'refresh',
+        },
+      });
       throw new UnauthorizedError('User not found or banned');
     }
 
     const tokens = generateTokenPair(user.id, user.role);
     const fullUser = await queryOne('SELECT * FROM users WHERE id = $1', [user.id]);
 
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'user',
+      actorId: user.id,
+      result: 'success',
+      statusCode: 200,
+      metadata: {
+        flow: 'refresh',
+      },
+    });
+
     res.json({
       ...tokens,
       user: fullUser,
     });
   } catch (error) {
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'login',
+      entityType: 'auth',
+      actorType: 'system',
+      result: 'failure',
+      failureReason: 'refresh_failed',
+      statusCode: 401,
+      metadata: {
+        flow: 'refresh',
+      },
+    });
     next(error);
   }
 });
 
 // Logout (client-side token deletion, but could add to blacklist)
-router.post('/logout', authenticate, async (_req, res) => {
+router.post('/logout', authenticate, async (req, res) => {
+  await tryLogSecurityEventFromRequest(req, {
+    action: 'logout',
+    entityType: 'auth',
+    actorType: 'user',
+    actorId: req.user!.userId,
+    result: 'success',
+    statusCode: 200,
+  });
+
   res.json({ message: 'Logged out' });
 });
 
@@ -256,10 +368,33 @@ router.delete('/me', authenticate, async (req, res, next) => {
 
     // Clean up verification codes, then delete user (CASCADE handles the rest)
     await query('DELETE FROM verification_codes WHERE phone = $1', [user.phone]);
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'user',
+      entityId: userId,
+      actorType: 'user',
+      actorId: userId,
+      result: 'success',
+      statusCode: 200,
+      oldValues: {
+        phoneMasked: `****${user.phone.slice(-4)}`,
+      },
+    });
+
     await query('DELETE FROM users WHERE id = $1', [userId]);
 
     res.json({ message: 'Account deleted' });
   } catch (error) {
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'user',
+      actorType: req.user ? 'user' : 'system',
+      actorId: req.user?.userId,
+      result: 'failure',
+      failureReason: 'account_delete_failed',
+      statusCode: 400,
+    });
     next(error);
   }
 });

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -316,6 +316,11 @@ router.post('/refresh', validate(refreshSchema), async (req, res, next) => {
       user: fullUser,
     });
   } catch (error) {
+    if (error instanceof UnauthorizedError) {
+      next(error);
+      return;
+    }
+
     await tryLogSecurityEventFromRequest(req, {
       action: 'login',
       entityType: 'auth',

--- a/packages/api/src/routes/connections.ts
+++ b/packages/api/src/routes/connections.ts
@@ -5,6 +5,7 @@ import { authenticate } from '../middleware/auth';
 import { query, queryOne } from '../config/database';
 import { parseQrData } from '../utils/jwt';
 import { NotFoundError, BadRequestError, ConflictError } from '../utils/errors';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
 
@@ -156,7 +157,20 @@ router.post('/', authenticate, validate(createConnectionSchema), async (req, res
       [inserted!.id]
     );
 
-    // TODO: Log to audit_log
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'create',
+      entityType: 'connection',
+      entityId: inserted!.id,
+      actorType: 'user',
+      actorId: currentUserId,
+      result: 'success',
+      statusCode: 201,
+      metadata: {
+        otherUserId,
+        eventId: eventId || null,
+        justVerified,
+      },
+    });
 
     res.status(201).json({ connection, justVerified });
   } catch (error) {
@@ -183,7 +197,19 @@ router.delete('/:id', authenticate, async (req, res, next) => {
       throw new BadRequestError('Not authorized to remove this connection');
     }
 
-    // TODO: Log to audit_log before deletion (capture old_values)
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'delete',
+      entityType: 'connection',
+      entityId: connection.id,
+      actorType: 'user',
+      actorId: userId,
+      result: 'success',
+      statusCode: 204,
+      oldValues: {
+        userAId: connection.user_a_id,
+        userBId: connection.user_b_id,
+      },
+    });
 
     await query('DELETE FROM connections WHERE id = $1', [req.params.id]);
 

--- a/packages/api/src/routes/events.ts
+++ b/packages/api/src/routes/events.ts
@@ -42,6 +42,7 @@ router.get('/', authenticate, validate(listEventsSchema), async (req, res, next)
     const events = await query(
       `SELECT
          e.*,
+         COALESCE(e.posh_event_url, CASE WHEN e.posh_event_id IS NOT NULL THEN 'https://posh.vip/e/' || e.posh_event_id ELSE NULL END) AS posh_event_url,
          (SELECT url FROM event_images WHERE event_id = e.id ORDER BY sort_order ASC LIMIT 1) AS hero_image_url,
          (SELECT COUNT(*)::int FROM event_images WHERE event_id = e.id) AS image_count,
          (SELECT COUNT(*)::int FROM customer_products WHERE event_id = e.id AND status = 'active') AS partner_count
@@ -84,6 +85,7 @@ router.get('/:id', authenticate, async (req, res, next) => {
     const event = await queryOne(
       `SELECT
          e.*,
+         COALESCE(e.posh_event_url, CASE WHEN e.posh_event_id IS NOT NULL THEN 'https://posh.vip/e/' || e.posh_event_id ELSE NULL END) AS posh_event_url,
          COALESCE(
            (SELECT json_agg(ei ORDER BY ei.sort_order)
             FROM event_images ei WHERE ei.event_id = e.id),

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -6,44 +6,77 @@ import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
 
+function safeEquals(a: string, b: string): boolean {
+  const left = Buffer.from(a);
+  const right = Buffer.from(b);
+  return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
 // Posh webhook endpoint
+// Posh sends the shared secret as a plain header value in `Posh-Secret`.
+// We also support the legacy `x-posh-signature` HMAC approach for backwards
+// compatibility — if neither header is present the request is rejected.
 router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): Promise<void> => {
   try {
-    // Verify webhook signature
-    const signature = req.headers['x-posh-signature'] as string;
+    const rawBody = Buffer.isBuffer(req.body)
+      ? req.body
+      : Buffer.from(
+          typeof req.body === 'string'
+            ? req.body
+            : req.body
+              ? JSON.stringify(req.body)
+              : ''
+        );
 
-    if (!signature || !config.posh.webhookSecret) {
+    // --- Authenticate the request ---
+    const poshSecretHeader = req.headers['posh-secret'];
+    const hmacSignatureHeader = req.headers['x-posh-signature'];
+    const poshSecret = Array.isArray(poshSecretHeader)
+      ? poshSecretHeader[0]
+      : poshSecretHeader;
+    const hmacSignature = Array.isArray(hmacSignatureHeader)
+      ? hmacSignatureHeader[0]
+      : hmacSignatureHeader;
+
+    if (!config.posh.webhookSecret) {
       await tryLogSecurityEventFromRequest(req, {
         action: 'reject',
         entityType: 'webhook',
         actorType: 'system',
         result: 'failure',
-        failureReason: !signature ? 'missing_signature' : 'missing_webhook_secret',
+        failureReason: 'missing_webhook_secret',
         statusCode: 401,
-        metadata: {
-          source: 'posh',
-        },
+        metadata: { source: 'posh' },
       });
       res.status(401).json({ message: 'Unauthorized' });
       return;
     }
 
-    const expectedSignature = crypto
-      .createHmac('sha256', config.posh.webhookSecret)
-      .update(req.body)
-      .digest('hex');
+    let authenticated = false;
 
-    if (signature !== expectedSignature) {
+    // Method 1: Plain shared-secret header (Posh-Secret)
+    if (poshSecret) {
+      authenticated = safeEquals(poshSecret, config.posh.webhookSecret);
+    }
+
+    // Method 2: HMAC signature header (x-posh-signature) — legacy/fallback
+    if (!authenticated && hmacSignature) {
+      const expectedSignature = crypto
+        .createHmac('sha256', config.posh.webhookSecret)
+        .update(rawBody)
+        .digest('hex');
+      authenticated = safeEquals(hmacSignature, expectedSignature);
+    }
+
+    if (!authenticated) {
       await tryLogSecurityEventFromRequest(req, {
         action: 'reject',
         entityType: 'webhook',
         actorType: 'system',
         result: 'failure',
-        failureReason: 'invalid_signature',
+        failureReason: !poshSecret && !hmacSignature ? 'missing_signature' : 'invalid_signature',
         statusCode: 401,
-        metadata: {
-          source: 'posh',
-        },
+        metadata: { source: 'posh' },
       });
       res.status(401).json({ message: 'Invalid signature' });
       return;
@@ -51,7 +84,7 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
 
     let payload: { type: string; [key: string]: unknown };
     try {
-      payload = JSON.parse(req.body.toString()) as { type: string; [key: string]: unknown };
+      payload = JSON.parse(rawBody.toString()) as { type: string; [key: string]: unknown };
     } catch {
       await tryLogSecurityEventFromRequest(req, {
         action: 'reject',

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -1,4 +1,4 @@
-import { Router, raw } from 'express';
+import { Router, Response, raw } from 'express';
 import crypto from 'crypto';
 import { config } from '../config/env';
 import { processPoshWebhook } from '../services/posh';
@@ -10,6 +10,14 @@ function safeEquals(a: string, b: string): boolean {
   const left = Buffer.from(a);
   const right = Buffer.from(b);
   return left.length === right.length && crypto.timingSafeEqual(left, right);
+}
+
+function respondWebhook(res: Response, statusCode: number, message: string): void {
+  if (config.posh.webhookCompatMode) {
+    res.status(200).json({ message: 'Webhook received' });
+    return;
+  }
+  res.status(statusCode).json({ message });
 }
 
 // Posh webhook endpoint
@@ -46,9 +54,13 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
         result: 'failure',
         failureReason: 'missing_webhook_secret',
         statusCode: 401,
-        metadata: { source: 'posh' },
+        metadata: {
+          source: 'posh',
+          responseMode: config.posh.webhookCompatMode ? 'compat_always_200' : 'strict_status',
+          logicalStatusCode: 401,
+        },
       });
-      res.status(401).json({ message: 'Unauthorized' });
+      respondWebhook(res, 401, 'Unauthorized');
       return;
     }
 
@@ -76,9 +88,13 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
         result: 'failure',
         failureReason: !poshSecret && !hmacSignature ? 'missing_signature' : 'invalid_signature',
         statusCode: 401,
-        metadata: { source: 'posh' },
+        metadata: {
+          source: 'posh',
+          responseMode: config.posh.webhookCompatMode ? 'compat_always_200' : 'strict_status',
+          logicalStatusCode: 401,
+        },
       });
-      res.status(401).json({ message: 'Invalid signature' });
+      respondWebhook(res, 401, 'Invalid signature');
       return;
     }
 
@@ -95,9 +111,11 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
         statusCode: 400,
         metadata: {
           source: 'posh',
+          responseMode: config.posh.webhookCompatMode ? 'compat_always_200' : 'strict_status',
+          logicalStatusCode: 400,
         },
       });
-      res.status(400).json({ message: 'Malformed payload' });
+      respondWebhook(res, 400, 'Malformed payload');
       return;
     }
 
@@ -111,6 +129,7 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
       statusCode: 200,
       metadata: {
         source: 'posh',
+        responseMode: config.posh.webhookCompatMode ? 'compat_always_200' : 'strict_status',
       },
     });
 
@@ -125,8 +144,14 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
       statusCode: 500,
       metadata: {
         source: 'posh',
+        responseMode: config.posh.webhookCompatMode ? 'compat_always_200' : 'strict_status',
+        logicalStatusCode: 500,
       },
     });
+    if (config.posh.webhookCompatMode) {
+      res.status(200).json({ message: 'Webhook received' });
+      return;
+    }
     next(error);
   }
 });

--- a/packages/api/src/routes/webhooks.ts
+++ b/packages/api/src/routes/webhooks.ts
@@ -2,6 +2,7 @@ import { Router, raw } from 'express';
 import crypto from 'crypto';
 import { config } from '../config/env';
 import { processPoshWebhook } from '../services/posh';
+import { tryLogSecurityEventFromRequest } from '../services/audit';
 
 const router = Router();
 
@@ -12,6 +13,17 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
     const signature = req.headers['x-posh-signature'] as string;
 
     if (!signature || !config.posh.webhookSecret) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'webhook',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: !signature ? 'missing_signature' : 'missing_webhook_secret',
+        statusCode: 401,
+        metadata: {
+          source: 'posh',
+        },
+      });
       res.status(401).json({ message: 'Unauthorized' });
       return;
     }
@@ -22,15 +34,66 @@ router.post('/posh', raw({ type: 'application/json' }), async (req, res, next): 
       .digest('hex');
 
     if (signature !== expectedSignature) {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'webhook',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'invalid_signature',
+        statusCode: 401,
+        metadata: {
+          source: 'posh',
+        },
+      });
       res.status(401).json({ message: 'Invalid signature' });
       return;
     }
 
-    const payload = JSON.parse(req.body.toString());
+    let payload: { type: string; [key: string]: unknown };
+    try {
+      payload = JSON.parse(req.body.toString()) as { type: string; [key: string]: unknown };
+    } catch {
+      await tryLogSecurityEventFromRequest(req, {
+        action: 'reject',
+        entityType: 'webhook',
+        actorType: 'system',
+        result: 'failure',
+        failureReason: 'malformed_payload',
+        statusCode: 400,
+        metadata: {
+          source: 'posh',
+        },
+      });
+      res.status(400).json({ message: 'Malformed payload' });
+      return;
+    }
+
     await processPoshWebhook(payload);
+
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'verify',
+      entityType: 'webhook',
+      actorType: 'system',
+      result: 'success',
+      statusCode: 200,
+      metadata: {
+        source: 'posh',
+      },
+    });
 
     res.json({ message: 'Webhook processed' });
   } catch (error) {
+    await tryLogSecurityEventFromRequest(req, {
+      action: 'reject',
+      entityType: 'webhook',
+      actorType: 'system',
+      result: 'failure',
+      failureReason: 'webhook_processing_failed',
+      statusCode: 500,
+      metadata: {
+        source: 'posh',
+      },
+    });
     next(error);
   }
 });

--- a/packages/api/src/services/audit.ts
+++ b/packages/api/src/services/audit.ts
@@ -1,0 +1,145 @@
+import { Request } from 'express';
+import { query } from '../config/database';
+import { config } from '../config/env';
+
+type AuditAction =
+  | 'create'
+  | 'update'
+  | 'delete'
+  | 'login'
+  | 'logout'
+  | 'verify'
+  | 'reject'
+  | 'ban'
+  | 'unban'
+  | 'checkin';
+
+type ActorType = 'user' | 'admin' | 'system';
+type AuditResult = 'success' | 'failure';
+
+interface AuditEventInput {
+  action: AuditAction;
+  entityType: string;
+  entityId?: string | null;
+  actorType: ActorType;
+  actorId?: string | null;
+  adminActorId?: string | null;
+  result: AuditResult;
+  failureReason?: string | null;
+  requestId?: string | null;
+  route?: string | null;
+  method?: string | null;
+  statusCode?: number | null;
+  sourceIp?: string | null;
+  userAgent?: string | null;
+  oldValues?: Record<string, unknown> | null;
+  newValues?: Record<string, unknown> | null;
+  metadata?: Record<string, unknown> | null;
+}
+
+function compactObject(obj: Record<string, unknown> | null | undefined): Record<string, unknown> | null {
+  if (!obj) return null;
+
+  const entries = Object.entries(obj).filter(([, value]) => value !== undefined);
+  return entries.length > 0 ? Object.fromEntries(entries) : null;
+}
+
+function normalizeUserAgent(userAgent: string | undefined): string | null {
+  if (!userAgent) return null;
+  return userAgent.slice(0, 512);
+}
+
+function extractSourceIp(req: Request): string | null {
+  const forwarded = req.header('x-forwarded-for');
+  if (forwarded) {
+    const firstIp = forwarded.split(',')[0]?.trim();
+    if (firstIp) return firstIp;
+  }
+  return req.ip || null;
+}
+
+export async function logAuditEvent(event: AuditEventInput): Promise<void> {
+  if (!config.audit.enabled) {
+    return;
+  }
+
+  const oldValues = compactObject(event.oldValues);
+  const newValues = compactObject(event.newValues);
+  const metadata = compactObject(event.metadata);
+
+  await query(
+    `INSERT INTO audit_log (
+      action,
+      entity_type,
+      entity_id,
+      actor_id,
+      admin_actor_id,
+      actor_type,
+      result,
+      failure_reason,
+      request_id,
+      route,
+      method,
+      status_code,
+      source_ip,
+      user_agent,
+      environment,
+      metadata_version,
+      old_values,
+      new_values,
+      metadata,
+      occurred_at,
+      ingested_at
+    ) VALUES (
+      $1, $2, $3, $4, $5, $6, $7, $8,
+      $9, $10, $11, $12, $13, $14, $15, $16,
+      $17, $18, $19, NOW(), NOW()
+    )`,
+    [
+      event.action,
+      event.entityType,
+      event.entityId ?? null,
+      event.actorId ?? null,
+      event.adminActorId ?? null,
+      event.actorType,
+      event.result,
+      event.failureReason ?? null,
+      event.requestId ?? null,
+      event.route ?? null,
+      event.method ?? null,
+      event.statusCode ?? null,
+      event.sourceIp ?? null,
+      event.userAgent ?? null,
+      config.audit.environment,
+      config.audit.metadataVersion,
+      oldValues,
+      newValues,
+      metadata,
+    ]
+  );
+}
+
+type RequestAuditInput = Omit<AuditEventInput, 'requestId' | 'route' | 'method' | 'sourceIp' | 'userAgent'>;
+
+export async function logSecurityEventFromRequest(req: Request, event: RequestAuditInput): Promise<void> {
+  await logAuditEvent({
+    ...event,
+    requestId: req.requestId ?? null,
+    route: req.originalUrl,
+    method: req.method,
+    sourceIp: extractSourceIp(req),
+    userAgent: normalizeUserAgent(req.header('user-agent')),
+  });
+}
+
+export async function tryLogSecurityEventFromRequest(req: Request, event: RequestAuditInput): Promise<void> {
+  try {
+    await logSecurityEventFromRequest(req, event);
+  } catch (error) {
+    console.error('[AUDIT] Failed to write audit event', {
+      action: event.action,
+      entityType: event.entityType,
+      error,
+    });
+  }
+}

--- a/packages/api/src/services/posh.ts
+++ b/packages/api/src/services/posh.ts
@@ -2,6 +2,58 @@ import { query, queryOne } from '../config/database';
 import { sendSms } from './sms';
 import { sendEmail } from './email';
 
+function digitsOnly(value: string): string {
+  return value.replace(/\D/g, '');
+}
+
+async function tryImmediateReconcile(
+  poshOrderId: string,
+  eventId: string | null,
+  accountPhone: string | undefined,
+  orderNumber: string,
+  total: number,
+  purchasedAt: string | null,
+): Promise<void> {
+  if (!accountPhone) return;
+
+  const fullDigits = digitsOnly(accountPhone);
+  const localDigits = fullDigits.length > 10 ? fullDigits.slice(-10) : fullDigits;
+
+  const user = await queryOne<{ id: string }>(
+    `SELECT id FROM users
+     WHERE phone IS NOT NULL
+       AND (
+         regexp_replace(phone, '[^0-9]', '', 'g') = $1
+         OR regexp_replace(phone, '[^0-9]', '', 'g') = $2
+         OR regexp_replace(phone, '[^0-9]', '', 'g') = ('1' || $2)
+       )
+     LIMIT 1`,
+    [fullDigits, localDigits]
+  );
+
+  if (!user) return;
+
+  await query(
+    'UPDATE posh_orders SET user_id = $1 WHERE id = $2',
+    [user.id, poshOrderId]
+  );
+
+  if (!eventId) return;
+
+  await query(
+    `INSERT INTO tickets (user_id, event_id, posh_order_id, ticket_type, price, status, purchased_at)
+     SELECT $1, $2, $3, 'Posh', COALESCE($4::numeric, 0), 'purchased', COALESCE($5::timestamptz, NOW())
+     WHERE NOT EXISTS (
+       SELECT 1
+       FROM tickets t
+       WHERE t.event_id = $2
+         AND t.user_id = $1
+         AND t.status NOT IN ('cancelled', 'refunded')
+     )`,
+    [user.id, eventId, orderNumber, total, purchasedAt ? new Date(purchasedAt) : null]
+  );
+}
+
 // ────────────────────────────────────────────────────────────
 // Posh webhook payload types (based on actual Posh webhook format)
 // ────────────────────────────────────────────────────────────
@@ -100,6 +152,17 @@ async function handleNewOrder(data: PoshNewOrderPayload): Promise<void> {
     console.log('Duplicate Posh order, skipping:', orderNumberStr);
     return;
   }
+
+  // Reconcile immediately when the buyer already exists in the app.
+  // If no user is found, verify-code flow will reconcile later.
+  await tryImmediateReconcile(
+    inserted.id,
+    event?.id ?? null,
+    data.account_phone,
+    orderNumberStr,
+    data.total,
+    data.date_purchased,
+  );
 
   // Send invite to buyer so they can download the app and set up their profile
   const firstName = data.account_first_name || 'there';

--- a/packages/api/src/types/express.d.ts
+++ b/packages/api/src/types/express.d.ts
@@ -1,0 +1,12 @@
+import type { JwtPayload } from '../config/auth';
+
+declare global {
+  namespace Express {
+    interface Request {
+      user?: JwtPayload;
+      requestId?: string;
+    }
+  }
+}
+
+export {};

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -1,0 +1,193 @@
+import request from 'supertest';
+import { getApp } from './helpers/app';
+import { resetDb, getTestPool } from './helpers/db';
+import { resetFixtureCounters, createUser, createAdminUser } from './helpers/fixtures';
+import { adminToken, socialToken } from './helpers/auth';
+
+const app = getApp();
+
+beforeEach(async () => {
+  await resetDb();
+  resetFixtureCounters();
+});
+
+describe('Security Audit Logging', () => {
+  it('logs validation_failed for bad phone format in request-code', async () => {
+    const res = await request(app)
+      .post('/auth/request-code')
+      .send({ phone: '5551234567' });
+
+    expect(res.status).toBe(400);
+
+    const pool = getTestPool();
+    const auditRes = await pool.query(
+      `SELECT action, entity_type, result, failure_reason, route, method, status_code
+       FROM audit_log
+       WHERE route = '/auth/request-code'
+       ORDER BY occurred_at DESC
+       LIMIT 1`
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      action: 'reject',
+      entity_type: 'validation',
+      result: 'failure',
+      failure_reason: 'validation_failed',
+      route: '/auth/request-code',
+      method: 'POST',
+      status_code: 400,
+    });
+  });
+
+  it('logs verification_code_expired when verification code is expired', async () => {
+    const phone = '+15559999091';
+
+    const codeRes = await request(app)
+      .post('/auth/request-code')
+      .send({ phone });
+
+    expect(codeRes.status).toBe(200);
+
+    const pool = getTestPool();
+    await pool.query(
+      `UPDATE verification_codes
+       SET expires_at = NOW() - INTERVAL '1 minute'
+       WHERE phone = $1`,
+      [phone]
+    );
+
+    const verifyRes = await request(app)
+      .post('/auth/verify-code')
+      .send({ phone, code: codeRes.body.devCode });
+
+    expect(verifyRes.status).toBe(400);
+
+    const auditRes = await pool.query(
+      `SELECT action, entity_type, result, failure_reason, route, method, status_code, metadata
+       FROM audit_log
+       WHERE route = '/auth/verify-code'
+         AND result = 'failure'
+       ORDER BY occurred_at DESC
+       LIMIT 1`
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      action: 'login',
+      entity_type: 'auth',
+      result: 'failure',
+      failure_reason: 'verification_code_expired',
+      route: '/auth/verify-code',
+      method: 'POST',
+      status_code: 400,
+    });
+    expect(auditRes.rows[0].metadata).toMatchObject({ flow: 'verify_code' });
+  });
+
+  it('logs ban action for privileged admin user mutation', async () => {
+    const adminUser = await createAdminUser();
+    const targetUser = await createUser({ role: 'user' });
+
+    const res = await request(app)
+      .patch(`/admin/users/${targetUser.id}`)
+      .set('Authorization', `Bearer ${adminToken(adminUser.id)}`)
+      .send({ banned: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body.user.banned).toBe(true);
+
+    const pool = getTestPool();
+    const auditRes = await pool.query(
+      `SELECT action, entity_type, entity_id, actor_type, admin_actor_id, result, status_code, old_values, new_values
+       FROM audit_log
+       WHERE entity_type = 'user'
+         AND entity_id = $1
+         AND action = 'ban'
+       ORDER BY occurred_at DESC
+       LIMIT 1`,
+      [targetUser.id]
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      action: 'ban',
+      entity_type: 'user',
+      entity_id: targetUser.id,
+      actor_type: 'admin',
+      admin_actor_id: adminUser.id,
+      result: 'success',
+      status_code: 200,
+    });
+    expect(auditRes.rows[0].old_values).toMatchObject({ banned: false });
+    expect(auditRes.rows[0].new_values).toMatchObject({ banned: true });
+  });
+
+  it('logs connection create and delete audit events', async () => {
+    const userA = await createUser();
+    const userB = await createUser();
+
+    const createRes = await request(app)
+      .post('/connections')
+      .set('Authorization', `Bearer ${socialToken(userA.id)}`)
+      .send({ qrData: `industrynight://connect/${userB.id}` });
+
+    expect(createRes.status).toBe(201);
+    const connectionId = createRes.body.connection.id;
+
+    const pool = getTestPool();
+    const createAudit = await pool.query(
+      `SELECT action, entity_type, entity_id, actor_type, actor_id, result, status_code
+       FROM audit_log
+       WHERE entity_type = 'connection'
+         AND entity_id = $1
+         AND action = 'create'
+       ORDER BY occurred_at DESC
+       LIMIT 1`,
+      [connectionId]
+    );
+
+    expect(createAudit.rows).toHaveLength(1);
+    expect(createAudit.rows[0]).toMatchObject({
+      action: 'create',
+      entity_type: 'connection',
+      entity_id: connectionId,
+      actor_type: 'user',
+      actor_id: userA.id,
+      result: 'success',
+      status_code: 201,
+    });
+
+    const deleteRes = await request(app)
+      .delete(`/connections/${connectionId}`)
+      .set('Authorization', `Bearer ${socialToken(userA.id)}`);
+
+    expect(deleteRes.status).toBe(204);
+
+    const deleteAudit = await pool.query(
+      `SELECT action, entity_type, entity_id, actor_type, actor_id, result, status_code, old_values
+       FROM audit_log
+       WHERE entity_type = 'connection'
+         AND entity_id = $1
+         AND action = 'delete'
+       ORDER BY occurred_at DESC
+       LIMIT 1`,
+      [connectionId]
+    );
+
+    expect(deleteAudit.rows).toHaveLength(1);
+    expect(deleteAudit.rows[0]).toMatchObject({
+      action: 'delete',
+      entity_type: 'connection',
+      entity_id: connectionId,
+      actor_type: 'user',
+      actor_id: userA.id,
+      result: 'success',
+      status_code: 204,
+    });
+    expect(deleteAudit.rows[0].old_values).toMatchObject({
+      userAId: expect.any(String),
+      userBId: expect.any(String),
+    });
+  });
+});

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -2,7 +2,7 @@ import request from 'supertest';
 import { getApp } from './helpers/app';
 import { resetDb, getTestPool } from './helpers/db';
 import { resetFixtureCounters, createUser, createAdminUser } from './helpers/fixtures';
-import { adminToken, socialToken } from './helpers/auth';
+import { adminRefreshToken, adminToken, socialToken } from './helpers/auth';
 
 const app = getApp();
 
@@ -83,6 +83,36 @@ describe('Security Audit Logging', () => {
       status_code: 400,
     });
     expect(auditRes.rows[0].metadata).toMatchObject({ flow: 'verify_code' });
+  });
+
+  it('logs a single invalid_refresh_token event for rejected social refresh tokens', async () => {
+    const user = await createUser();
+
+    const res = await request(app)
+      .post('/auth/refresh')
+      .send({ refreshToken: adminRefreshToken(user.id) });
+
+    expect(res.status).toBe(401);
+
+    const pool = getTestPool();
+    const auditRes = await pool.query(
+      `SELECT action, entity_type, result, failure_reason, route, method, status_code, metadata
+       FROM audit_log
+       WHERE route = '/auth/refresh'
+       ORDER BY occurred_at DESC`
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      action: 'login',
+      entity_type: 'auth',
+      result: 'failure',
+      failure_reason: 'invalid_refresh_token',
+      route: '/auth/refresh',
+      method: 'POST',
+      status_code: 401,
+    });
+    expect(auditRes.rows[0].metadata).toMatchObject({ flow: 'refresh' });
   });
 
   it('logs ban action for privileged admin user mutation', async () => {

--- a/packages/api/tests/middleware.test.ts
+++ b/packages/api/tests/middleware.test.ts
@@ -42,11 +42,8 @@ describe('Token Family Separation', () => {
       .get('/auth/me')
       .set('Authorization', `Bearer ${token}`);
 
-    // The authenticate middleware checks type === 'access' but does NOT check
-    // tokenFamily. This is intentional — social routes accept any valid access
-    // token. The separation is enforced at the admin end.
-    // If this behavior changes in the future, update this test.
-    expect(res.status).toBe(200);
+    // authenticate now enforces tokenFamily === 'social'.
+    expect(res.status).toBe(401);
   });
 
   it('social token CANNOT access admin routes (GET /admin/dashboard)', async () => {

--- a/packages/api/tests/setup.ts
+++ b/packages/api/tests/setup.ts
@@ -45,17 +45,22 @@ export default async function setup() {
     password: 'test',
   }));
 
-  // Apply the baseline migration
-  console.log('📦 Applying baseline migration...');
+  // Apply all migrations in filename order.
+  console.log('📦 Applying migrations...');
 
   const client = new Client({ connectionString });
   await client.connect();
 
-  const migrationPath = path.resolve(
-    __dirname, '..', '..', 'database', 'migrations', '001_baseline_schema.sql'
-  );
-  const migrationSql = fs.readFileSync(migrationPath, 'utf-8');
-  await client.query(migrationSql);
+  const migrationsDir = path.resolve(__dirname, '..', '..', 'database', 'migrations');
+  const migrationFiles = fs.readdirSync(migrationsDir)
+    .filter((file) => file.endsWith('.sql'))
+    .sort();
+
+  for (const migrationFile of migrationFiles) {
+    const migrationPath = path.join(migrationsDir, migrationFile);
+    const migrationSql = fs.readFileSync(migrationPath, 'utf-8');
+    await client.query(migrationSql);
+  }
 
   await client.end();
 

--- a/packages/database/migrations/002_audit_security_foundation.sql
+++ b/packages/database/migrations/002_audit_security_foundation.sql
@@ -1,0 +1,92 @@
+-- 002_audit_security_foundation.sql
+-- Phase 1 security audit schema enhancements.
+
+DO $$
+BEGIN
+  CREATE TYPE actor_type AS ENUM ('user', 'admin', 'system');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$
+BEGIN
+  CREATE TYPE audit_result AS ENUM ('success', 'failure');
+EXCEPTION
+  WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE audit_log
+  ADD COLUMN IF NOT EXISTS admin_actor_id UUID REFERENCES admin_users(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS actor_type actor_type NOT NULL DEFAULT 'system',
+  ADD COLUMN IF NOT EXISTS result audit_result NOT NULL DEFAULT 'success',
+  ADD COLUMN IF NOT EXISTS failure_reason VARCHAR(100),
+  ADD COLUMN IF NOT EXISTS request_id UUID,
+  ADD COLUMN IF NOT EXISTS route VARCHAR(255),
+  ADD COLUMN IF NOT EXISTS method VARCHAR(10),
+  ADD COLUMN IF NOT EXISTS status_code INTEGER,
+  ADD COLUMN IF NOT EXISTS source_ip INET,
+  ADD COLUMN IF NOT EXISTS user_agent TEXT,
+  ADD COLUMN IF NOT EXISTS environment VARCHAR(20) NOT NULL DEFAULT 'development',
+  ADD COLUMN IF NOT EXISTS metadata_version INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS occurred_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW(),
+  ADD COLUMN IF NOT EXISTS ingested_at TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW();
+
+UPDATE audit_log
+SET actor_type = 'user'
+WHERE actor_id IS NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ck_audit_log_actor_identity'
+  ) THEN
+    ALTER TABLE audit_log
+    ADD CONSTRAINT ck_audit_log_actor_identity
+    CHECK (
+      (actor_type = 'user' AND actor_id IS NOT NULL AND admin_actor_id IS NULL)
+      OR (actor_type = 'admin' AND actor_id IS NULL AND admin_actor_id IS NOT NULL)
+      OR (actor_type = 'system' AND actor_id IS NULL AND admin_actor_id IS NULL)
+    );
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_constraint
+    WHERE conname = 'ck_audit_log_environment'
+  ) THEN
+    ALTER TABLE audit_log
+    ADD CONSTRAINT ck_audit_log_environment
+    CHECK (environment IN ('development', 'production', 'test'));
+  END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_audit_log_admin_actor ON audit_log(admin_actor_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_result ON audit_log(result);
+CREATE INDEX IF NOT EXISTS idx_audit_log_failure_reason ON audit_log(failure_reason);
+CREATE INDEX IF NOT EXISTS idx_audit_log_request_id ON audit_log(request_id);
+CREATE INDEX IF NOT EXISTS idx_audit_log_occurred_at ON audit_log(occurred_at DESC);
+CREATE INDEX IF NOT EXISTS idx_audit_log_action_result_time ON audit_log(action, result, occurred_at DESC);
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE EXCEPTION 'audit_log is immutable';
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_prevent_audit_log_update ON audit_log;
+CREATE TRIGGER trg_prevent_audit_log_update
+  BEFORE UPDATE ON audit_log
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_mutation();
+
+DROP TRIGGER IF EXISTS trg_prevent_audit_log_delete ON audit_log;
+CREATE TRIGGER trg_prevent_audit_log_delete
+  BEFORE DELETE ON audit_log
+  FOR EACH ROW
+  EXECUTE FUNCTION prevent_audit_log_mutation();

--- a/packages/database/migrations/003_events_posh_event_url.sql
+++ b/packages/database/migrations/003_events_posh_event_url.sql
@@ -1,0 +1,5 @@
+-- Add full Posh event URL storage to support direct social-app navigation.
+-- Keep posh_event_id as canonical linkage key for webhook reconciliation.
+
+ALTER TABLE events
+ADD COLUMN IF NOT EXISTS posh_event_url TEXT;

--- a/packages/shared/lib/api/admin_api.dart
+++ b/packages/shared/lib/api/admin_api.dart
@@ -216,6 +216,7 @@ class AdminApi {
     String? description,
     int? capacity,
     String? poshEventId,
+    String? poshEventUrl,
     String? marketId,
   }) async {
     final response = await _client.post<Map<String, dynamic>>(
@@ -229,6 +230,7 @@ class AdminApi {
         if (description != null) 'description': description,
         if (capacity != null) 'capacity': capacity,
         if (poshEventId != null) 'poshEventId': poshEventId,
+        if (poshEventUrl != null) 'poshEventUrl': poshEventUrl,
         if (marketId != null) 'marketId': marketId,
       },
     );
@@ -243,6 +245,7 @@ class AdminApi {
     DateTime? startTime,
     DateTime? endTime,
     String? poshEventId,
+    String? poshEventUrl,
     EventStatus? status,
     int? capacity,
     String? marketId,
@@ -255,6 +258,7 @@ class AdminApi {
     if (startTime != null)    body['startTime'] = startTime.toIso8601String();
     if (endTime != null)      body['endTime'] = endTime.toIso8601String();
     if (poshEventId != null)  body['poshEventId'] = poshEventId;
+    if (poshEventUrl != null) body['poshEventUrl'] = poshEventUrl;
     if (status != null)       body['status'] = status.name;
     if (capacity != null)     body['capacity'] = capacity;
     if (marketId != null)     body['marketId'] = marketId;

--- a/packages/shared/lib/models/event.dart
+++ b/packages/shared/lib/models/event.dart
@@ -68,6 +68,7 @@ class Event extends Equatable {
 
   final String? activationCode;
   final String? poshEventId;
+  final String? poshEventUrl;
 
   @JsonKey(fromJson: _eventStatusFromJson, toJson: _eventStatusToJson)
   final EventStatus status;
@@ -112,6 +113,7 @@ class Event extends Equatable {
     required this.endTime,
     this.activationCode,
     this.poshEventId,
+    this.poshEventUrl,
     this.status = EventStatus.draft,
     this.capacity,
     this.attendeeCount = 0,
@@ -143,6 +145,7 @@ class Event extends Equatable {
     DateTime? endTime,
     String? activationCode,
     String? poshEventId,
+    String? poshEventUrl,
     EventStatus? status,
     int? capacity,
     int? attendeeCount,
@@ -169,6 +172,7 @@ class Event extends Equatable {
       endTime: endTime ?? this.endTime,
       activationCode: activationCode ?? this.activationCode,
       poshEventId: poshEventId ?? this.poshEventId,
+      poshEventUrl: poshEventUrl ?? this.poshEventUrl,
       status: status ?? this.status,
       capacity: capacity ?? this.capacity,
       attendeeCount: attendeeCount ?? this.attendeeCount,
@@ -212,7 +216,7 @@ class Event extends Equatable {
         venueName, venueAddress,
         marketId, marketName,
         startTime, endTime,
-        activationCode, poshEventId,
+        activationCode, poshEventId, poshEventUrl,
         status, capacity, attendeeCount,
         heroImageUrl, imageCount, partnerCount,
         images, partners,

--- a/packages/shared/lib/utils/formatters.dart
+++ b/packages/shared/lib/utils/formatters.dart
@@ -28,6 +28,15 @@ String formatDateTime(DateTime dateTime) {
 String formatTimeRange(DateTime start, DateTime end) {
   final startTime = DateFormat.jm().format(start);
   final endTime = DateFormat.jm().format(end);
+  final sameDay = start.year == end.year &&
+      start.month == end.month &&
+      start.day == end.day;
+
+  if (!sameDay) {
+    final endDate = DateFormat.MMMd().format(end);
+    return '$startTime - $endDate $endTime';
+  }
+
   return '$startTime - $endTime';
 }
 

--- a/packages/social-app/lib/features/events/screens/activation_code_screen.dart
+++ b/packages/social-app/lib/features/events/screens/activation_code_screen.dart
@@ -28,6 +28,8 @@ class _ActivationCodeScreenState extends State<ActivationCodeScreen>
   final _codeController = TextEditingController();
   MobileScannerController? _scannerController;
   bool _isSubmitting = false;
+  String? _lastScannedPayload;
+  DateTime? _lastScanAt;
 
   @override
   void initState() {
@@ -66,6 +68,16 @@ class _ActivationCodeScreenState extends State<ActivationCodeScreen>
 
     final value = barcode!.rawValue!;
 
+    // Guard against rapid duplicate detections from the camera stream.
+    final now = DateTime.now();
+    if (_lastScannedPayload == value &&
+        _lastScanAt != null &&
+        now.difference(_lastScanAt!) < const Duration(seconds: 2)) {
+      return;
+    }
+    _lastScannedPayload = value;
+    _lastScanAt = now;
+
     // Expected: industrynight://checkin/{eventId}/{activationCode}
     if (!value.startsWith('industrynight://checkin/')) return;
 
@@ -82,6 +94,7 @@ class _ActivationCodeScreenState extends State<ActivationCodeScreen>
       return;
     }
 
+    _scannerController?.stop();
     _checkIn(scannedCode);
   }
 
@@ -123,13 +136,42 @@ class _ActivationCodeScreenState extends State<ActivationCodeScreen>
       context.pop(checkedInTicket);
     } on ApiException catch (e) {
       if (!mounted) return;
+
+      final isAlreadyCheckedIn = e.message.toLowerCase().contains('already checked in');
+      if (isAlreadyCheckedIn) {
+        setState(() => _isSubmitting = false);
+        await showDialog(
+          context: context,
+          barrierDismissible: false,
+          builder: (dialogContext) => AlertDialog(
+            title: const Text('Already Checked In'),
+            content: const Text('You are already checked in for this event.'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.of(dialogContext).pop(),
+                child: const Text('OK'),
+              ),
+            ],
+          ),
+        );
+        if (!mounted) return;
+        context.pop();
+        return;
+      }
+
       setState(() => _isSubmitting = false);
+      if (_tabController.index == 0) {
+        _scannerController?.start();
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         SnackBar(content: Text(e.message)),
       );
     } catch (e) {
       if (!mounted) return;
       setState(() => _isSubmitting = false);
+      if (_tabController.index == 0) {
+        _scannerController?.start();
+      }
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(content: Text('Check-in failed. Please try again.')),
       );

--- a/packages/social-app/lib/features/events/screens/event_detail_screen.dart
+++ b/packages/social-app/lib/features/events/screens/event_detail_screen.dart
@@ -23,9 +23,13 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
   String? _error;
   int _currentImageIndex = 0;
 
+  late final WidgetsBindingObserver _lifecycleObserver =
+      _EventDetailLifecycleObserver(onResumed: _handleAppResumed);
+
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(_lifecycleObserver);
     _loadEvent();
   }
 
@@ -78,6 +82,20 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
         _isLoadingTicket = false;
       });
     }
+  }
+
+  @override
+  void dispose() {
+    WidgetsBinding.instance.removeObserver(_lifecycleObserver);
+    super.dispose();
+  }
+
+  Future<void> _handleAppResumed() async {
+    if (!mounted || _isLoading) return;
+
+    // Pull fresh event + ticket state when returning from external apps (e.g. Posh)
+    // so ticket UI transitions without requiring logout/login.
+    await _loadEvent();
   }
 
   @override
@@ -390,6 +408,9 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
   }
 
   Widget _buildGetTicketsCard(Event event) {
+    final hasPoshLink =
+      event.poshEventUrl != null && event.poshEventUrl!.trim().isNotEmpty;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -406,16 +427,21 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
               style: AppTypography.bodyMedium.copyWith(color: AppColors.textSecondary),
               textAlign: TextAlign.center,
             ),
-            if (event.poshEventId != null) ...[
+            if (hasPoshLink) ...[
               const SizedBox(height: 12),
               SizedBox(
                 width: double.infinity,
                 child: ElevatedButton.icon(
                   onPressed: () async {
-                    final url = Uri.parse('https://posh.vip/e/${event.poshEventId}');
-                    if (await canLaunchUrl(url)) {
-                      await launchUrl(url, mode: LaunchMode.externalApplication);
+                    final url = _poshUriForEvent(event);
+                    if (url == null) {
+                      if (!mounted) return;
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('No valid Posh ticket link is configured for this event.')),
+                      );
+                      return;
                     }
+                    await _openTicketUrl(url);
                   },
                   icon: const Icon(Icons.open_in_new),
                   label: const Text('Get Tickets on Posh'),
@@ -426,6 +452,51 @@ class _EventDetailScreenState extends State<EventDetailScreen> {
         ),
       ),
     );
+  }
+
+  Uri? _poshUriForEvent(Event event) {
+    final rawUrl = (event.poshEventUrl != null && event.poshEventUrl!.trim().isNotEmpty)
+      ? event.poshEventUrl!.trim()
+      : null;
+
+    if (rawUrl == null) return null;
+
+    final withScheme = rawUrl.contains('://') ? rawUrl : 'https://$rawUrl';
+    return Uri.tryParse(withScheme);
+  }
+
+  Future<void> _openTicketUrl(Uri url) async {
+    try {
+      final launched = await launchUrl(url, mode: LaunchMode.externalApplication);
+      if (launched) return;
+    } catch (_) {
+      // Fall through to platform-default attempt.
+    }
+
+    try {
+      final launched = await launchUrl(url, mode: LaunchMode.platformDefault);
+      if (launched) return;
+    } catch (_) {
+      // Fall through to snackbar.
+    }
+
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('Could not open ticket link: $url')),
+    );
+  }
+}
+
+class _EventDetailLifecycleObserver with WidgetsBindingObserver {
+  final Future<void> Function() onResumed;
+
+  _EventDetailLifecycleObserver({required this.onResumed});
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    if (state == AppLifecycleState.resumed) {
+      onResumed();
+    }
   }
 }
 

--- a/scripts/coop/infra-rebuild.sh
+++ b/scripts/coop/infra-rebuild.sh
@@ -295,6 +295,7 @@ log_success "  Secrets Manager updated with endpoint: $NEW_RDS_ENDPOINT"
 DB_HOST_VAL="$NEW_RDS_ENDPOINT"
 DB_USER_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('username', '$RDS_MASTER_USER'))")
 DB_PASS_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin)['password'])")
+POSH_WEBHOOK_SECRET_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('POSH_WEBHOOK_SECRET', ''))")
 
 # Step 7: Apply Kubernetes manifests
 log_step $((++CURRENT_STEP)) $TOTAL_STEPS "Applying Kubernetes manifests..."
@@ -314,6 +315,15 @@ kube_cmd create secret generic industrynight-secrets \
   --from-literal=JWT_SECRET="$(openssl rand -base64 32)" \
   --from-literal=CORS_ORIGINS="$CORS_ORIGINS" \
   -n "$K8S_NAMESPACE"
+
+if [[ -n "$POSH_WEBHOOK_SECRET_VAL" ]]; then
+  kube_cmd patch secret industrynight-secrets -n "$K8S_NAMESPACE" --type merge \
+    -p "{\"stringData\":{\"POSH_WEBHOOK_SECRET\":\"$POSH_WEBHOOK_SECRET_VAL\"}}" >/dev/null
+  log_info "  Added POSH_WEBHOOK_SECRET to K8s secret"
+else
+  log_warn "  POSH_WEBHOOK_SECRET missing in Secrets Manager; webhook signature validation will reject requests"
+fi
+
 log_info "  K8s secrets created"
 
 # Deployment, Service, Ingress

--- a/scripts/coop/infra-rebuild.sh
+++ b/scripts/coop/infra-rebuild.sh
@@ -296,6 +296,7 @@ DB_HOST_VAL="$NEW_RDS_ENDPOINT"
 DB_USER_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('username', '$RDS_MASTER_USER'))")
 DB_PASS_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin)['password'])")
 POSH_WEBHOOK_SECRET_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('POSH_WEBHOOK_SECRET', ''))")
+POSH_WEBHOOK_COMPAT_MODE_VAL=$(echo "$SECRET_JSON" | python3 -c "import sys, json; print(json.load(sys.stdin).get('POSH_WEBHOOK_COMPAT_MODE', 'false'))")
 
 # Step 7: Apply Kubernetes manifests
 log_step $((++CURRENT_STEP)) $TOTAL_STEPS "Applying Kubernetes manifests..."
@@ -323,6 +324,10 @@ if [[ -n "$POSH_WEBHOOK_SECRET_VAL" ]]; then
 else
   log_warn "  POSH_WEBHOOK_SECRET missing in Secrets Manager; webhook signature validation will reject requests"
 fi
+
+kube_cmd patch secret industrynight-secrets -n "$K8S_NAMESPACE" --type merge \
+  -p "{\"stringData\":{\"POSH_WEBHOOK_COMPAT_MODE\":\"$POSH_WEBHOOK_COMPAT_MODE_VAL\"}}" >/dev/null
+log_info "  Added POSH_WEBHOOK_COMPAT_MODE=$POSH_WEBHOOK_COMPAT_MODE_VAL to K8s secret"
 
 log_info "  K8s secrets created"
 


### PR DESCRIPTION
Summary: Stabilizes Posh RSVP to ticket to check-in flow across API/admin/social. Highlights: webhook-time reconcile for existing users; verify-code fallback; removed read-side reconcile side effects; added posh_event_url end-to-end; improved scanner duplicate handling and already-checked-in UX; overnight-safe admin scheduling; POSH_WEBHOOK_COMPAT_MODE wiring. Validation: api smoke (dev) passed; API typecheck passed; manual dev E2E confirmed webhook ingest, order-user linkage, ticket creation, app resume refresh, and successful check-in persistence.