### PR TITLE
chore: park recovered accelint workstream context

### DIFF
--- a/accelint/ACCELINT_CONTEXT.md
+++ b/accelint/ACCELINT_CONTEXT.md
@@ -1,0 +1,254 @@
+# Accelint — Context Handoff Document
+
+**Owner:** Jeff Simpson (jeff@rhodiuslabs.com)
+**Role:** Transformation Lead (new internal hire)
+**Last Updated:** March 22, 2026
+**Status:** Early-stage ramp-up — see §8 for known gaps
+
+---
+
+## 1. What This Document Is
+
+This is the context handoff document for the Accelint AI-assisted development transformation initiative. It exists so any AI assistant (or new session) can pick up immediately with full situational awareness — the same pattern used in the Industry Night project (`industry_night_app_developer_context_handoff.md`).
+
+When starting a new session on Accelint work, load this document and say: *"Read ACCELINT_CONTEXT.md and tell me what we're working on."*
+
+---
+
+## 2. The Company: Accelint
+
+Accelint is a defense software company whose development teams build next-generation applications for the US military and allied nation militaries. Primary domains:
+
+- **Command & Control (C2)** — decision support, situational awareness, operational coordination
+- **ISR (Intelligence, Surveillance, Reconnaissance)** — sensor fusion, data pipelines, analysis tooling
+- **Logistics & Planning** — supply chain, mission planning, resource allocation applications
+
+The software these teams produce is mission-critical. Some of it runs in contested, degraded, or disconnected environments (DDIL). Some interfaces with systems where errors have operational consequences. This is not a typical commercial software shop.
+
+---
+
+## 3. Jeff's Role and Mandate
+
+**Title:** Transformation Lead (internal hire — not external consultant)
+**Mandate:** Agent of change — transition Accelint's development teams from traditional to AI-assisted development practices
+**Reporting:** TBD / still being established
+**Tenure:** New — actively ramping up
+
+The transformation is not being imposed top-down by leadership as a fait accompli. Jeff is entering an environment where:
+
+- Most "mainline programmers" have not made the transition to AI-assisted development
+- Some individuals may have personal experience with AI tools, but it's not institutionalized
+- The culture is military-software-adjacent: rigorous, process-oriented, potentially skeptical of anything that smells like "vibe coding"
+- There is no single homogeneous tech stack — multiple programs, multiple stacks
+
+Jeff's job is to earn trust, demonstrate value, build a repeatable practice, and make the case to multiple audiences (developers, product managers, executives, program offices) that this transition is both possible and necessary.
+
+---
+
+## 4. The Transformation Vision
+
+### What "AI-Assisted Development" Means Here
+
+This is NOT:
+- AI writing code without human review
+- Replacing engineers with AI tools
+- Moving fast and breaking things
+- Using unapproved tools on classified networks
+
+This IS:
+- Engineers using AI as a force multiplier for the work they already do well
+- Automating the expensive, repetitive, low-value parts of software development (boilerplate, documentation, test scaffolding, refactoring)
+- Elevating code review, architecture, and mission-critical design — the parts that require human judgment
+- Building institutional knowledge about which tools work, under what conditions, with what guardrails
+
+### Why It Matters Now
+
+The commercial software industry has already normalized AI-assisted development. The productivity gap between AI-assisted and non-AI-assisted teams is measurable and widening. Defense software programs face budget pressure, schedule pressure, and talent competition. The transition is not optional in the long run — the question is whether Accelint leads it or reacts to it.
+
+---
+
+## 5. The Defense Software Context: Constraints That Cannot Be Ignored
+
+This section is critical. Many AI adoption playbooks written for commercial software are not directly applicable in a defense context. The following constraints shape every tooling recommendation.
+
+### 5.1 Classification and Network Topology
+
+Defense development environments typically span multiple classification levels:
+
+| Network | Classification | AI Tool Access |
+|---------|---------------|----------------|
+| NIPR (NIPRNet) | Unclassified / CUI | Commercial cloud AI tools *may* be usable with controls |
+| SIPR (SIPRNet) | Secret | Air-gapped — no commercial cloud AI; local/on-prem models only |
+| JWICS / SAP | TS/SCI and above | Fully air-gapped — local models only, with additional vetting |
+
+**Implication:** Any tool recommendation must specify which networks it applies to. A blanket "use GitHub Copilot" recommendation is incomplete — it may be valid on NIPR and completely inappropriate on SIPR.
+
+> ⚠️ **Gap:** The classification posture of Accelint's specific programs is not yet fully known. The framework below is written to be adaptable. As program-specific constraints become clear, update the tooling recommendations accordingly.
+
+### 5.2 Regulatory and Compliance Framework
+
+| Framework | Relevance |
+|-----------|-----------|
+| **ITAR** (International Traffic in Arms Regulations) | Restrictions on sharing controlled technical data with AI tools — input data matters, not just output |
+| **CMMC** (Cybersecurity Maturity Model Certification) | Level 2/3 requirements govern how CUI is handled, including AI-generated code containing CUI |
+| **FedRAMP** | Cloud AI tools used for government work must be FedRAMP-authorized (High, where required) |
+| **NIST SP 800-171** | CUI handling controls; AI tool selection must not create uncontrolled disclosure vectors |
+| **Program-specific AIS/ATO** | Individual programs may have Authority to Operate (ATO) requirements that gate tool adoption |
+
+**Implication:** The governance framework (§7 below) must integrate with existing compliance posture, not sit beside it.
+
+### 5.3 The Cultural Terrain
+
+Military-adjacent software developers tend to be:
+
+- **Rigorous and process-oriented** — they have formal code review, testing requirements, and documentation standards because the stakes demand it
+- **Skeptical of hype** — they've seen many "next big thing" tools come and go; AI needs to demonstrate value, not just promise it
+- **Protective of correctness** — any tool that introduces risk to mission-critical logic will be resisted, and rightly so
+- **Responsive to demonstrated capability** — if you show it works, with evidence, they'll adopt it
+
+The framing of this initiative matters enormously. "AI writes your code" is a losing message. "AI handles the busywork so you can focus on the hard problems" is the right message.
+
+---
+
+## 6. The Transformation Roadmap (Provisional)
+
+This is an early-stage framework. It will be refined as Jeff gets the lay of the land at Accelint.
+
+### Phase 0 — Reconnaissance (Weeks 1–4)
+- Map the programs, stacks, and team structures
+- Identify classification posture per program
+- Find the early adopters (there are always a few — find them)
+- Audit existing tool approvals and procurement vehicles
+- Understand the SDLC: how code gets written, reviewed, tested, and shipped today
+
+### Phase 1 — Foundation (Weeks 4–12)
+- Establish governance framework: approved tools list, data handling rules, red lines
+- Stand up a pilot on a non-classified, lower-stakes program or feature
+- Train the first cohort of 5–10 developers
+- Instrument measurement baseline: velocity, defect rate, documentation quality
+
+### Phase 2 — Proof (Months 3–6)
+- Publish pilot results internally
+- Expand to 2–3 additional programs
+- Begin building internal capability: champions, documentation, internal training
+- First executive briefing with data
+
+### Phase 3 — Scale (Months 6–18)
+- Institutionalize: AI-assisted development is the default, not the exception
+- Integrate into onboarding for new developers
+- Governance model is self-sustaining
+- Continuous improvement loop: new tools evaluated against the approved framework
+
+---
+
+## 7. Governance Framework (First Draft)
+
+### Approved Use Cases (Unclassified Environments, Subject to Tool Approval)
+- Code completion and suggestion (GitHub Copilot, Tabnine, or equivalent)
+- Documentation generation (docstrings, API docs, MIL-STD artifacts)
+- Test case generation and coverage analysis
+- Code review assistance (vulnerability scanning, style enforcement)
+- Refactoring legacy code (particularly C++ and Java modernization)
+- Architecture analysis and diagramming
+- Boilerplate and scaffolding generation
+- Regex, SQL, and configuration file generation
+
+### Approved Use Cases (Air-Gapped / Classified Environments)
+Same list as above, but only with **locally-deployed models** that have been vetted and approved for the classification level. This includes:
+- Ollama-hosted open-source models (Llama, Code Llama, Mistral, etc.) on approved hardware
+- Government-cloud AI services with appropriate ATO (Azure Government OpenAI, AWS GovCloud Bedrock)
+
+### Red Lines — Non-Negotiable
+1. **No classified or CUI data in unapproved AI tools.** This is not a gray area.
+2. **No AI-generated code for safety-critical or mission-critical logic without explicit human expert review.** AI suggests; engineers decide.
+3. **No tool adoption without program-level ATO or compliance review.**
+4. **No AI-generated code committed without human review.** AI is not a committer.
+5. **No ITAR-controlled technical data as AI input** unless the tool has been specifically evaluated and cleared for that data.
+
+### The Human-in-the-Loop Requirement
+AI outputs in this context are always suggestions, never decisions. The engineer is responsible for every line of code that ships. This is both a cultural norm and, in some programs, a contractual requirement.
+
+---
+
+## 8. Known Gaps (as of March 22, 2026)
+
+These are the things Jeff does not yet know, which will shape the specifics of the transformation approach:
+
+| Gap | Why It Matters | How to Close It |
+|-----|---------------|-----------------|
+| Classification posture by program | Determines which tools can be recommended | Program office conversations in Phase 0 |
+| Existing approved tool inventory | May already have Copilot/etc. approved — don't reinvent | IT/ISSO conversation |
+| Primary development stacks | Tooling effectiveness varies by language | Team mapping in Phase 0 |
+| Team size and distribution | Shapes pilot selection and rollout pace | Org chart + team leads |
+| SDLC maturity | Determines where AI integrates (pre-commit, CI, review, docs) | Code review + CI pipeline review |
+| Key stakeholders to win | Who can block, who can champion | Stakeholder mapping |
+| Existing AI anxiety or resistance | Shapes the communication strategy | Developer conversations, 1:1s |
+| Budget and procurement vehicles | Determines which commercial tools are accessible | Program manager / contracting |
+
+---
+
+## 9. Deliverables Being Created
+
+The following materials are being developed as part of the initial Accelint engagement setup:
+
+| Deliverable | Purpose | Audience | Status |
+|-------------|---------|---------|--------|
+| `ACCELINT_CONTEXT.md` (this file) | AI session context handoff | AI assistants, Jeff | ✅ Draft |
+| `ai-dev-playbook.md` | Transformation methodology guide | Internal reference | 🔵 In progress |
+| Adversarial Panel Review | Multi-evaluator critique of the playbook | Jeff's QA | ⬜ Pending |
+| Developer Briefing Deck (.pptx) | "Here's what changes and what doesn't" | Accelint developers | ⬜ Pending |
+| Exec/Product/Mgmt Briefing Deck (.pptx) | Business case + roadmap + governance | Leadership, program managers | ⬜ Pending |
+
+---
+
+## 10. Industry Night as a Case Study Reference
+
+[Industry Night](../CLAUDE.md) is a separate project — a platform for discovering and managing industry night events (hair stylists, makeup artists, photographers, creative workers). It is Jeff's ongoing development project and serves as the **primary live case study** for AI-assisted development practices.
+
+**Why it's relevant to Accelint:**
+
+Industry Night is built with a full modern stack (Flutter/Dart, Node.js/TypeScript, PostgreSQL, AWS/EKS) and is being developed using the CODEX prompt library — a structured set of AI execution prompts, each with acceptance criteria, test suites, and adversarial panel review. This is the methodology being generalized for Accelint.
+
+**Key concepts from IN that translate directly:**
+- **CODEX prompt library** (`docs/codex/`) — structured AI execution prompts with stated goals, acceptance criteria, and test suites. This is the template for how Accelint should structure AI-assisted work: not "ask the AI to write code" but "give the AI a prompt with a contract."
+- **Adversarial panel review** — four role-specialized evaluators (Correctness, Security, Test Coverage, Patterns) review AI-generated code before merge. Directly applicable to defense software where code review rigor matters.
+- **A/B branch protocol** — running the same prompt on two AI models on separate branches, then comparing outputs. Useful for calibrating which models work best for which types of tasks.
+- **CLAUDE.md / context handoff pattern** — the discipline of maintaining a living context document so AI sessions are always fully oriented. This document is that pattern applied to Accelint.
+- **Completion Report + Interrogative Session** — each AI execution produces a structured self-report and a human qualitative review. Creates institutional memory and enables retrospective analysis.
+
+**What NOT to use from IN directly:**
+- The specific tech stack (Flutter, PostgreSQL, etc.) is not relevant unless Accelint uses similar tools
+- The specific schema and API design are IN-specific
+- The business domain (events, creative workers) is obviously not applicable
+
+When referencing Industry Night in Accelint briefings, frame it as: *"Here is a real project where this methodology is being applied right now. These are the tools, this is the process, these are the results."*
+
+---
+
+## 11. Jeff's Working Philosophy
+
+A few principles that should inform how any AI assistant works with Jeff on this initiative:
+
+1. **Honest over comfortable.** Jeff wants to know what doesn't work, what the risks are, and where the gaps are. Don't paper over hard problems.
+2. **Practical over theoretical.** Recommendations need to be actionable. "It depends" is a valid answer only when followed by what it depends on and how to find out.
+3. **Context-preserving.** Jeff works across long sessions and multiple projects. Document decisions, rationale, and open questions explicitly — don't assume context will survive a context reset.
+4. **Military software demands rigor.** The Accelint audience is not a consumer startup. They need to see that AI-assisted development increases, not decreases, rigor and correctness. Lead with quality, not velocity.
+5. **Earn trust before asking for change.** The transition will fail if it's imposed. The approach is to demonstrate value on small, real problems, then let adoption spread organically from the early adopters.
+
+---
+
+## 12. Quick Reference: Key Files
+
+| File | Location | Purpose |
+|------|----------|---------|
+| This document | `accelint/ACCELINT_CONTEXT.md` | Session context handoff |
+| Transformation playbook | `accelint/docs/ai-dev-playbook.md` | Full methodology guide |
+| Adversarial panel template | `accelint/panel/adversarial-panel-review.md` | Review framework |
+| Developer deck | `accelint/decks/developer-briefing.pptx` | Developer-facing slides |
+| Exec deck | `accelint/decks/exec-briefing.pptx` | Leadership-facing slides |
+| IN CODEX library | `../docs/codex/` | Live case study reference |
+| IN CLAUDE.md | `../CLAUDE.md` | IN project context |
+
+---
+
+*This document is living. Update §8 (Known Gaps) as Jeff learns more during Phase 0 reconnaissance. Update §6 (Roadmap) when the program landscape becomes clearer.*

--- a/accelint/docs/personal-oplan.md
+++ b/accelint/docs/personal-oplan.md
@@ -1,0 +1,256 @@
+# Personal OPLAN — AI Transformation at Accelint
+
+**Classification:** Personal / Private
+**Owner:** Jeff Simpson
+**Date:** March 22, 2026
+**Status:** Living document — update as terrain becomes clear
+
+> This is a commander's personal estimate. Written to be honest, not comfortable. If this document ever leaves your hands, that's a security failure — treat it accordingly.
+
+---
+
+## 1. Situation
+
+### 1.1 The Terrain
+
+Accelint is not a cohesive company. It is a five-company roll-up (Hypergiant, Forward Slope, Highbury Defense Group, SoarTech, Systems Innovation Engineering) unified under a single brand since 2024, backed by Trive Capital. The companies have different cultures, different tech stacks, different contract vehicles, and different levels of institutional maturity. They are still figuring out what "Accelint" means.
+
+This matters because:
+- There is no single development culture to transform — there are at least five.
+- Program offices may have more real authority than any Accelint corporate function.
+- Loyalties are often to the legacy company, not the Accelint umbrella.
+- Change is already happening (new CEO, brand consolidation) — yours is not the only disruption in flight.
+
+The environment is classified-network-aware, process-oriented, and contract-driven. Nothing moves without authority, documentation, and precedent. Speed is not a default virtue here. Correctness and survivability are.
+
+### 1.2 Friendly Forces — Assets and Relationships
+
+| Name | Role | Relationship | Strategic Value |
+|------|------|-------------|-----------------|
+| **Andrew Nugent** | CTO | Interviewed and hired me | Executive sponsor; controls technical direction; can open any door |
+| **Daniel Gelyana** | President, Global C2 & Cyber Solutions | Interviewed and hired me | Senior portfolio authority; visibility into a major segment; politically heavyweight |
+| **Rob Peabody** | Chief Engineer | Personal colleague, 15+ years | Technical credibility validator; can vouch for my judgment to skeptical engineers; not in my reporting chain |
+| **Carlos Perishetti** | Former CEO | Personal colleague and friend, 15+ years | Informal institutional knowledge; relationship capital; knows the culture and the landmines |
+
+**How to use these assets:** These relationships are not levers to pull casually or to win arguments. They are insurance and access. Use Nugent and Gelyana to open doors in Phase 0 that would otherwise take months. Use Peabody to technically validate the approach with engineers who need to hear it from someone who has bled in their world. Use Carlos for off-the-record intelligence — who are the real power brokers, where are the bodies buried, what has been tried and failed before.
+
+**Important discipline:** Never go around Jason Mak in a way that is visible. If Nugent or Gelyana reach in directly, that will make Mak defensive and adversarial. The goal is to use executive access to shape conditions and context, not to route around the org chart on tactical decisions.
+
+### 1.3 Friction Points
+
+**Jason Mak — VP of Software**
+This is the most important relationship to manage, and it starts in a structurally awkward position. He did not have input on my hire. A senior transformation mandate was placed inside his organization without his consent. This is a flag.
+
+What Mak likely feels: his authority over his engineers is being implicitly questioned. The message he received, whether intended or not, is "your team needs to change, and we're bringing someone in from outside to make that happen." That is a threat to a VP, regardless of how compelling the transformation rationale is.
+
+What Mak is probably not: a villain. He's likely a capable technical manager who has built something he's protective of. The correct frame is not "how do I get around him" but "how do I make him believe this makes his organization better and makes him look good."
+
+Threat modes to watch for:
+- **Access friction** — I "need to get on his calendar" to meet with engineers; meetings get delayed
+- **Information filtering** — I only hear about the teams and programs he wants me to see
+- **Silent non-compliance** — he nods at the initiative in meetings and does nothing to facilitate it
+- **Credit and narrative capture** — if the transformation starts working, he reframes it as his initiative
+- **Failure amplification** — any stumble in the pilot gets surfaced upward as evidence the approach doesn't work
+
+None of these require Mak to be malicious. Most can happen through normal managerial self-protection.
+
+**The legacy company loyalists**
+In each of the five constituent companies, there are senior engineers and leads who built the culture that exists. They did not ask for transformation, and some will view it as an implicit criticism of how they work. The most dangerous are the ones who are highly regarded and have deep program relationships — they have the standing to make my life difficult without corporate consequences.
+
+**The weak-fundamentals contingent**
+There are engineers on these teams who have job security through complexity — through being the one person who understands a legacy system, through working slowly in ways that are hard to audit, or through accumulating institutional knowledge that nobody else has. AI-assisted development will make this kind of job security much harder to maintain. They will not say this out loud. But they will feel it, and some will act on it.
+
+### 1.4 Unknown Quantities
+
+| Unknown | Why It Matters | How to Resolve |
+|---------|---------------|----------------|
+| Classification posture by program | Determines which tools can be used where | Phase 0 program office visits |
+| Existing approved tool inventory | May already have Copilot, etc. — don't reinvent | ISSO/IT conversation early |
+| Primary development stacks per team | Tool effectiveness varies by language | Team mapping in Phase 0 |
+| SDLC maturity per legacy company | Where AI integrates depends on current process | PR/CI pipeline review |
+| Who the real early adopters are | Always 2-3 people already using AI — find them fast | Developer 1:1s in Phase 0 |
+| What has been tried before | If AI tools have been floated and failed, need to know why | Carlos + historical intel |
+| Budget and procurement vehicles | Determines which commercial tools are accessible | Program manager / contracting conversation |
+
+---
+
+## 2. Mission
+
+Establish AI-assisted development as the default practice across Accelint's engineering organization within 18 months, starting from zero institutional practice and against active cultural resistance, in a classified-network-constrained environment.
+
+Success is not adoption of a specific tool. Success is a measurable, documented change in team velocity, defect rates, and documentation quality — with a self-sustaining internal capability that does not depend on my continued presence.
+
+---
+
+## 3. Commander's Intent
+
+At 18 months, I want to be able to walk out of Accelint and have the transformation continue without me. That means:
+
+- At least 3 internal champions who can train and evangelize independently
+- A documented governance framework integrated into existing compliance posture (not bolted on the side)
+- Pilot data published internally: before/after velocity, defect rate, documentation quality
+- A tool-approval process that is routine, not a heroic exception
+- Jason Mak understanding this was good for his organization
+
+If I'm still fighting for permission to run a pilot at month 6, I have failed at Phase 0.
+
+---
+
+## 4. Execution
+
+### Phase 0 — Reconnaissance (Weeks 1–6)
+*Goal: Know the terrain before making any commitments.*
+
+**Priority tasks:**
+1. **Map every program's classification posture.** Don't recommend tools until you know which networks they operate on. One bad tool recommendation on a SIPR program will permanently damage credibility.
+2. **Meet every key engineering lead.** Not to pitch — to listen. Understand their stack, their pain points, their current workflow. Don't mention AI transformation in the first meeting. Ask about what slows them down.
+3. **Find the early adopters.** Ask indirectly: "Do you use any AI tools personally?" There are always 2-3 people already doing this quietly. They become your first cohort.
+4. **Get the approved tool inventory from IT/ISSO.** Work with what's already approved before fighting procurement battles.
+5. **Audit the SDLC by legacy company.** How does code get from written to shipped? Where are the friction points? Where would AI most naturally integrate?
+6. **Understand Jason Mak's priorities.** What is he measured on? What keeps him up at night? Find the overlap with what this transformation delivers.
+7. **Run Carlos for background.** Off the record: who are the real power brokers? What has been tried and failed? Where are the landmines?
+
+**What NOT to do in Phase 0:**
+- Don't announce the transformation broadly
+- Don't make tool recommendations before knowing classification posture
+- Don't hold workshops or training before you have a pilot cohort
+- Don't go around Mak, visibly
+
+**Phase 0 deliverable:** A briefing for Nugent and Gelyana (and Mak) with: program map, classification posture by team, approved tool inventory, identified pilot candidates, and recommended Phase 1 approach. This briefing IS the transition from Phase 0 to Phase 1.
+
+---
+
+### Phase 1 — Foundation (Months 1–3)
+*Goal: Run one successful, documented pilot. Generate evidence.*
+
+**Pilot selection criteria:**
+- Unclassified or CUI-minimum program (not SIPR for the first pilot)
+- Team with at least one willing early adopter
+- Work that has measurable output (velocity, defect rate, documentation quality)
+- Low enough stakes that a stumble doesn't become a narrative weapon
+- High enough visibility that a success gets noticed
+
+**Establish governance before the pilot starts.** This is not optional in a defense environment. The governance framework gives skeptics a process to trust even if they don't trust the technology. It also protects you — if something goes wrong, the response is "our governance framework caught it and here's what we learned," not "we were experimenting without guardrails."
+
+Minimum governance elements for the pilot:
+- Approved tools list (even if it's one tool)
+- Data handling rules (what can go into the tool, what cannot)
+- Review requirement (all AI-generated code requires human review before commit)
+- Escalation path (who gets called if something feels wrong)
+
+**Train the first cohort.** 5–10 engineers. Hands-on, not lecture. Pick people who already have strong fundamentals — the AI amplification effect is most visible and most legible on engineers who know what they're doing.
+
+**Instrument a baseline before you start.** You cannot show improvement without a before. Measure: commit velocity, PR review cycle time, defect density, documentation coverage. Even imperfect measurement is better than none.
+
+---
+
+### Phase 2 — Proof (Months 3–6)
+*Goal: Publish results. Expand. First executive briefing with data.*
+
+**Publish the pilot results internally** — not just the numbers, but the narrative. What did engineers actually do differently? What did they say? What surprised them? Case studies with names (with permission) are more persuasive than dashboards.
+
+**Expand to 2–3 additional programs.** Prioritize programs where you have a sympathetic lead or where the early adopter is already seeding interest.
+
+**Brief Nugent and Gelyana with data.** This is the moment where the initiative gets institutionalized or stays a pilot. Come with: before/after metrics, engineer testimonials, a proposed governance model for scale, and a budget ask if needed.
+
+**Develop internal champions.** At least one person per pilot program who can train others without you. This is how the initiative survives budget cuts, personnel changes, or political shifts.
+
+**Brief Mak separately before the executive briefing.** Give him the results first. Let him have input on the narrative. This is how you make him a collaborator instead of a bystander who hears about his organization's results secondhand.
+
+---
+
+### Phase 3 — Scale (Months 6–18)
+*Goal: AI-assisted development is the default. Self-sustaining.*
+
+- Integrate into onboarding for new engineers
+- Governance model maintained by a standing working group (not just me)
+- Tool evaluation pipeline: new tools assessed against the framework routinely
+- Continuous measurement loop: velocity, defects, documentation quality tracked program-wide
+- Begin classified environment strategy (SIPR/JWICS local model deployment)
+
+---
+
+## 5. Political Navigation — Rules of Engagement
+
+**The Mak Principle: Make him the hero.**
+Every initiative that succeeds should be something Jason Mak can claim credit for facilitating. This is not sycophancy — it's smart. A VP who feels ownership of a transformation is a completely different animal from one who feels like it was done to him. Give him early access to results. Ask for his input before decisions are made. When things work, use language like "Jason's teams have been early adopters here." He will reward this with access, cooperation, and eventually, advocacy.
+
+**Use executive access surgically.**
+Nugent and Gelyana opened the door. That is different from a standing invitation to bypass the chain. Use them to: set the mandate clearly at the start, open specific doors that are blocked (a program that won't engage, a tool approval that's stalled), and validate results publicly. Do not use them to win internal arguments with Mak or individual program leads — that creates resentment that outlasts the win.
+
+**Peabody as technical conscience.**
+Rob Peabody's value is in the engineering community, not in executive meetings. The engineers who are skeptical of me — a "transformation lead" who may or may not understand what they actually do — will be more open if Peabody signals that this is technically credible. Engage him early and often on the technical methodology. Let him poke holes in the approach; if he ends up endorsing it, that endorsement carries real weight.
+
+**Carlos for intelligence.**
+Carlos should be an off-the-record resource, not a public one. Using a former CEO as a visible ally will make current leadership uncomfortable. Use the relationship for intelligence, pattern-matching, and frank feedback — not for positioning.
+
+**Documentation as protection.**
+In an environment where sabotage is possible, documentation is armor. Every decision, every recommendation, every result should be written down and shared with the relevant stakeholders. This serves three purposes: it makes my reasoning auditable, it makes it harder to rewrite history after a success, and it makes it impossible to claim "nobody told me" if an initiative gets obstructed.
+
+**Earn technical credibility early.**
+I will be assumed to be a management consultant with a PowerPoint until proven otherwise. The fastest way to earn credibility with engineers is to sit next to them, look at their actual code, understand their actual tools and constraints, and demonstrate that I know what I'm talking about technically. The AI-assisted development methodology is not abstract — it has concrete, demonstrable practices. Show them, don't tell them.
+
+---
+
+## 6. Threat Assessment and Countermeasures
+
+### Technical Resistance
+**Form:** "AI tools don't work for our domain / stack / classification level / problem type"
+**Reality:** Often partially true. Defense software problems are real and different. Acknowledge it.
+**Countermeasure:** Never claim AI tools solve every problem. Lead with specific, relevant use cases (test generation, documentation, boilerplate) that are defensible regardless of domain. Let early adopters demonstrate domain-specific value; their word carries more weight than mine.
+
+### Political Resistance
+**Form:** Delayed meetings, vague commitments, "I need to check with X" indefinitely, budget questions that never resolve
+**Reality:** Passive obstruction that is plausibly deniable
+**Countermeasure:** Create written commitments with timelines wherever possible. Use meeting follow-up emails to document what was agreed. Escalate through Nugent/Gelyana only after documented attempts to resolve at the appropriate level. Never escalate on the first or second block — that looks reactive. The third documented block with a clear paper trail is a different conversation.
+
+### Failure Amplification
+**Form:** A stumble in the pilot gets surfaced as "evidence it doesn't work"
+**Reality:** Every pilot has stumbles; the question is whether they're treated as learning or as verdict
+**Countermeasure:** Frame the pilot explicitly as a learning exercise from the start, not a proof. Publish a "what we learned" alongside "what worked." Pre-define what constitutes failure and success with stakeholders before the pilot starts — if nobody agreed on success criteria upfront, any outcome can be spun.
+
+### Credit Capture
+**Form:** If the transformation works, others claim it; if it fails, I own it
+**Reality:** Classic organizational politics
+**Countermeasure:** Maintain a documented record of decisions, recommendations, and results. Brief Nugent/Gelyana directly and regularly with dated updates. This is not about credit — it's about having an accurate institutional record.
+
+### The Weak-Fundamentals Threat
+**Form:** Engineers who feel threatened by AI tooling becoming active resistors or manufacturing political friction
+**Reality:** They will rarely say "I'm threatened by this." They will say "this doesn't work for our problem" or "the security risk is unacceptable" or "our team doesn't have time for training"
+**Countermeasure:** Do not engage this argument at the level of the objection. Acknowledge the concern, address the surface-level issue, and keep moving. The natural selection that happens as AI-assisted development matures is not something I need to manage proactively — it will surface through standard performance dynamics. My job is to create the conditions; I am not responsible for every individual's adaptation.
+
+---
+
+## 7. Personal Conduct Rules
+
+1. **Never threaten.** Every communication — verbal, written, in a briefing — should feel collaborative, not evaluative. I am not auditing these teams. I am offering them a capability they didn't have.
+
+2. **Always bring evidence.** Opinion without evidence gets dismissed in a defense culture. Every recommendation should have a citation: a benchmark, a case study, an internal data point. The CODEX methodology and the Industry Night case study are not just process artifacts — they are evidence that this approach produces results.
+
+3. **Acknowledge the constraints.** Defense software is not a consumer startup. ITAR, CMMC, FedRAMP, ATOs — these are real constraints and treating them as bureaucratic nuisances will permanently damage credibility. Lead with constraint-awareness, not tool evangelism.
+
+4. **Don't outpace the culture.** Velocity is not a virtue in this environment. A change that sticks is worth more than a change that moves fast and gets reversed.
+
+5. **Separate transformation from performance management.** If an engineer is underperforming, that is Jason Mak's problem to manage, not mine. Do not let the AI transformation become a mechanism for personnel decisions — it will poison the well and create exactly the resistance I'm trying to avoid.
+
+6. **Protect the methodology.** The CODEX framework — structured prompts with acceptance criteria, adversarial review, A/B testing, completion reports — is the intellectual core of what I'm bringing. Be willing to adapt the tooling to the environment, but protect the methodology. The methodology is what makes this rigor, not chaos.
+
+7. **Keep a personal log.** At the end of every significant week: what happened, what I learned, what I'm changing. This is not for anyone else — it's for my own context maintenance and pattern recognition.
+
+---
+
+## 8. Success Metrics — Personal
+
+| Metric | 3 Months | 6 Months | 18 Months |
+|--------|----------|----------|-----------|
+| Pilot programs running | 1 | 2–3 | All willing programs |
+| Trained engineers | 5–10 | 25–50 | 100+ |
+| Internal champions | 1–2 | 5–8 | 15+ |
+| Tool approvals secured | 1 | 3–5 | Ongoing process |
+| Mak relationship | Neutral → Cooperative | Cooperative | Advocate |
+| Nugent/Gelyana confidence | Maintained | Growing | "This is working" |
+| Executive briefing delivered | Phase 0 report | Results briefing | Annual review |
+
+---
+
+*Update this document after Phase 0 reconnaissance is complete. The terrain will look different once you've been inside for 30 days.*

--- a/accelint/docs/team-education-plan.md
+++ b/accelint/docs/team-education-plan.md
@@ -1,0 +1,265 @@
+# AI-Assisted Development — Team Education and Management Plan
+
+**Owner:** Jeff Simpson
+**Date:** March 22, 2026
+**Audience:** Internal reference — Jeff's working document for team engagement strategy
+**Status:** Living document — update as teams are mapped in Phase 0
+
+---
+
+## 1. The Honest Framing
+
+Before planning how to teach this, it's important to be clear about what's actually true — not the marketing version, but the operational reality that needs to underpin every decision made about sequencing, messaging, and who gets trained first.
+
+### What AI-Assisted Development Actually Is
+
+AI-assisted development is a force multiplier. Like any force multiplier, it amplifies what's already there. A strong engineer with solid fundamentals, good architectural judgment, and the ability to communicate decisions clearly will become significantly more capable. A weak engineer who hides behind complexity, accumulates institutional knowledge as job security, and cannot communicate the reasoning behind their code will find AI-assisted development actively uncomfortable. The tool exposes the gap.
+
+This is not something to announce. It does not belong in any training materials or briefing decks. But it must be understood clearly before making any decisions about who gets trained first, what success looks like, and how to handle the engineers who struggle.
+
+### What Changes
+
+- **Velocity changes.** A strong engineer with AI assistance can produce significantly more — more code, more tests, more documentation — per unit of time. This is measurable and will be visible quickly.
+- **Code review becomes more important, not less.** AI-generated code must be reviewed by engineers who understand what the code is supposed to do. The review requirement goes up, not down. Engineers who cannot do effective code review become bottlenecks.
+- **Communication becomes a primary skill.** Writing a precise prompt for an AI code agent is fundamentally an act of communication — defining the goal, the constraints, the acceptance criteria, the context. Engineers who communicate poorly will produce poor AI output regardless of the tool. The ability to articulate what you want precisely is now a core engineering competency.
+- **The "I wrote this" accountability does not change.** Every line of code that ships is owned by a human engineer. AI suggests; engineers decide. In a defense environment, this is both an operational requirement and a contractual one in many programs.
+
+### What Does Not Change
+
+- Code review requirements
+- Testing requirements
+- Security controls
+- Documentation standards — in fact, AI can dramatically improve documentation quality and coverage
+- The engineer's responsibility for correctness
+- Human-in-the-loop decision-making on mission-critical logic
+- Classification controls — classified data does not go into unapproved tools, full stop
+
+### The Natural Selection Reality
+
+Some engineers will thrive with this transition. Some will struggle. The ones who thrive share identifiable characteristics: they have strong fundamentals, they communicate clearly, they are intellectually curious, and they are comfortable having their judgment questioned by a tool. The ones who struggle are often the opposite: they rely on accumulated complexity as protection, they communicate poorly, and they experience AI suggestions as a threat rather than an input.
+
+This natural selection will happen on its own. It does not need to be managed as part of the transformation initiative. The job is to create conditions for adoption and measure results — not to make personnel decisions. Those surface through normal performance management channels, on their own timeline.
+
+---
+
+## 2. Team Segmentation
+
+Every team has roughly the same distribution. Identify these groups before planning any training.
+
+### Early Adopters (roughly 10–15% of any team)
+These engineers are often already using AI tools personally — GitHub Copilot on personal projects, ChatGPT for debugging, Claude for documentation. They are not waiting for permission. They are waiting for acknowledgment, institutional support, and the opportunity to do this openly without feeling like they're doing something unauthorized.
+
+**Strategy:** Find them in Phase 0 through direct conversation. Ask casually: "Do you use any AI tools personally?" They will tell you. These are your first cohort. Fast-track them. Give them structure (the CODEX methodology) and make them the proof of concept. Then make them champions — explicitly ask them to share their experience with peers.
+
+### Pragmatic Majority (roughly 60–70% of any team)
+These engineers do not have a strong prior position on AI tools. They will adopt if adoption is clearly beneficial, well-supported, and not a risk to them. They are watching the early adopters. If the early adopters succeed and speak positively about the experience, the pragmatic majority moves. If the early adopters struggle or if the tools feel threatening, they wait.
+
+**Strategy:** Serve this group through evidence and social proof. Do not pitch them on the idea — show them results from colleagues they respect. Formal training happens here after the early adopters have demonstrated value.
+
+### Skeptics (roughly 15–20% of any team)
+These engineers have objections. Some objections are principled and correct ("this tool can't handle our classification requirements" or "AI-generated code in safety-critical systems needs more scrutiny"). Some are cultural and protective. Both deserve to be taken seriously.
+
+**Strategy:** Do not try to convert skeptics in Phase 0 or Phase 1. Acknowledge their concerns explicitly. Address the legitimate ones with specific answers. Give them time. Skeptics who see results from colleagues they respect often become the most thoughtful and valuable practitioners — they push on the right things.
+
+### Resistors (5–10% of any team)
+These engineers will not adopt regardless of evidence, support, or social proof. Some are protecting job security. Some have philosophical objections. Some are simply done changing how they work.
+
+**Strategy:** Do not spend resources trying to convert resistors. Do not make them adversaries by pressuring them. Let the initiative succeed around them. They will either quietly comply when the momentum is undeniable, or they will self-select out on their own timeline. This is not a transformation outcome — it is a performance management outcome, and it belongs there.
+
+---
+
+## 3. The Curriculum
+
+AI-assisted development is a skill, not a tool preference. It requires learning. The curriculum below is progressive — each level builds on the last, and engineers should not advance before the previous level is practiced and comfortable.
+
+### Level 0: Orientation — What This Is and Isn't
+**Audience:** All teams, before any hands-on work
+**Format:** 60-minute working session, not a lecture
+**Goal:** Correct the misconceptions that create resistance before they harden
+
+Key messages:
+- AI does not write your code. You write your code. AI accelerates the process.
+- Nothing about your review requirements, testing standards, or security controls changes.
+- Your engineering judgment is what makes AI output usable. Without it, the output is noise.
+- In classified environments, specific tools apply to specific networks. We will be precise about this.
+- We are here because the commercial industry is already doing this, the productivity gap is widening, and our programs cannot afford to fall behind.
+
+What to demonstrate: A live coding session where an engineer uses AI assistance on a real problem from their domain — boilerplate generation, test scaffolding, documentation. Not a synthetic demo. A real problem, with the messiness and iteration that comes with it.
+
+---
+
+### Level 1: AI as Pair Programmer
+**Audience:** Early adopters first; pragmatic majority once early adopters are comfortable
+**Format:** Hands-on lab, 3–4 hours
+**Goal:** Productive daily use of AI for low-risk, high-frequency tasks
+
+Skills taught:
+- Effective prompting: how to be precise about what you want (goal, constraints, context, format)
+- Code completion and suggestion workflows (how to use suggestions without accepting blindly)
+- Documentation generation: docstrings, API documentation, inline comments
+- Boilerplate and scaffolding: repetitive structural code, config files, schema definitions
+- Debugging assistance: using AI to reason through errors and unexpected behavior
+
+**The most important habit to establish at Level 1:** Every AI output gets read before it gets used. No blind acceptance. This is non-negotiable and must be established as muscle memory before the engineer advances.
+
+Defense-specific considerations:
+- Unclassified networks: use the approved commercial tools
+- CUI environments: verify data handling requirements before any input
+- SIPR/JWICS: locally-deployed models only (Ollama, Azure Government OpenAI, AWS GovCloud Bedrock — as applicable and approved)
+
+---
+
+### Level 2: AI as Reviewer
+**Audience:** Engineers who have completed Level 1 and practiced for 2–4 weeks
+**Format:** Hands-on lab, 2–3 hours, plus ongoing integration into code review workflow
+**Goal:** Using AI as a first-pass reviewer to improve code quality before human review
+
+Skills taught:
+- Code review prompting: how to ask for specific vulnerability classes, style issues, and logic gaps
+- Security-focused prompting: SQL injection patterns, input validation gaps, auth bypass risks
+- Refactoring assistance: identifying and improving complex or poorly-structured code
+- Test gap analysis: asking AI to identify cases not covered by existing tests
+
+**The key discipline at Level 2:** AI review catches things; it does not catch everything. Human review is still required. AI review is a quality gate, not a quality ceiling. Engineers who treat AI review as a replacement for human review are making a mistake.
+
+---
+
+### Level 3: AI as Scaffolder — The CODEX Approach
+**Audience:** Engineers who have completed Level 2; pilot teams with specific feature work to do
+**Format:** Workshop + ongoing practice with real work
+**Goal:** Structured, contract-driven AI execution that produces verifiable, reviewable output
+
+This is where the Industry Night CODEX methodology becomes directly applicable. The core principle: you do not just "ask the AI to write something." You give the AI a contract — a structured prompt with a stated goal, acceptance criteria, context files, and a test specification. The AI's output is measurable against the contract.
+
+A CODEX-style execution prompt contains:
+- **Goal:** A precise 1–3 sentence description of what must be produced
+- **Context:** Specific files, documentation, and constraints the AI must read before starting
+- **Acceptance Criteria:** Verifiable, binary conditions the output must satisfy
+- **Technical Spec:** Implementation constraints, function signatures, file locations, error handling requirements
+- **Test Suite:** Specific test cases that will fail if the acceptance criteria are not met
+- **Completion Report:** A structured self-report the AI fills in after execution
+- **Interrogative Session:** A set of questions the human engineer asks to quality-check the AI's work before it goes to review
+
+Why this matters in a defense context: structured prompts with acceptance criteria are directly analogous to requirements documents and test plans — artifacts the culture already understands and trusts. This is not "vibe coding." This is requirements-driven development with AI assistance.
+
+---
+
+### Level 4: AI-Native Workflow — Advanced Practice
+**Audience:** Champions and senior practitioners; optional for the broader team
+**Format:** Ongoing; not a single event
+**Goal:** Full integration of AI assistance into the development workflow; mentorship and evangelism capability
+
+Advanced practices:
+- **A/B model testing:** Running the same prompt on two different AI models on separate branches, comparing outputs on correctness, security, test coverage, and codebase fit before merging
+- **Adversarial panel review:** Four-dimensional review of AI-generated code (Correctness, Security, Test Coverage, Patterns) before high-stakes merges
+- **Prompt library development:** Building a team-specific CODEX library of reusable, high-quality execution prompts for the team's common task types
+- **Model selection discipline:** Knowing which tasks benefit from the most capable model vs. the fastest and most cost-effective one
+
+---
+
+## 4. What Changes in Management
+
+The transformation is not just about tools. It changes how work looks, how it is measured, and what management needs to attend to. These changes need to be understood before they create friction.
+
+### Velocity Expectations
+Output per engineer increases — sometimes dramatically for well-scoped tasks. This is good news, but it creates management questions: Are we comparing engineers fairly if some are using AI assistance and some are not? Are we adjusting sprint capacity expectations? Are we re-evaluating which tasks are worth doing now that the cost of doing them has dropped?
+
+These are questions for Jason Mak and program managers to work through. My job is to surface them, not answer them unilaterally.
+
+### Code Review Volume and Importance
+More code gets produced. That means more code gets reviewed. Code review capacity may become the constraint. Engineers who are good reviewers become more valuable. Programs that have weak review practices will feel the strain faster.
+
+Implication: code review capability needs to scale with adoption. This may mean formalizing review processes that are currently ad-hoc, or training engineers specifically in effective AI-output review.
+
+### Measuring Output vs. Activity
+One of the most common ways engineers resist accountability is by conflating activity (hours worked, meetings attended, complexity of the problems they "own") with output (working code, passing tests, shipped features, good documentation). AI-assisted development makes output more visible and more comparable. Engineers who were protected by the opacity of their work will find that protection eroding.
+
+This is not something to advertise. But it shapes what metrics to establish in the pilot and what management conversations to expect.
+
+### The Communication Premium
+The engineers who succeed most with AI-assisted development are the ones who communicate well — who can write a precise goal, who can articulate constraints clearly, who can specify acceptance criteria. These are also the engineers who write good commit messages, good PR descriptions, good design documents. The transformation effectively raises the floor on communication competence.
+
+Teams with strong written communication culture will adopt faster. Teams with weak written communication culture will need foundational work alongside the AI tooling.
+
+---
+
+## 5. Training Delivery Principles
+
+### Hands-On Over Lecture
+Nothing about AI-assisted development is learned by watching a presentation. Every training session must include hands-on work with real tools on real problems — ideally from the engineer's own codebase and domain.
+
+### Problems Over Demos
+A curated demo where everything works is less persuasive than a live session where things go sideways and get recovered. The willingness to demonstrate messiness builds more trust than polish.
+
+### Peer Instruction Over External Instruction
+Once the early adopter cohort has 4–6 weeks of practice, they should be doing the Level 1 and Level 2 training for their own peers. My role shifts from instructor to curriculum designer and quality controller. Peer instruction is more credible and more scalable.
+
+### Voluntary Before Mandatory
+The pilot is voluntary. The first cohort should want to be there. Mandatory training — especially on something as culturally charged as AI tools — produces compliance, not adoption. Adoption happens when engineers choose to use the tools because they make their work better.
+
+Mandates, if they ever become necessary, come after the transformation has demonstrated clear value. They should never be the mechanism that drives Phase 0 or Phase 1.
+
+### Small Cohorts
+Training cohorts should be 5–12 engineers. Larger than 12 and the hands-on work becomes a spectator sport. Smaller than 5 and there's not enough peer interaction to create social proof.
+
+---
+
+## 6. Metrics and Measurement
+
+Measurement must begin before the pilot starts. Without a baseline, there is no before/after story.
+
+### Baseline Metrics to Establish
+- **Commit velocity:** commits per engineer per sprint
+- **PR cycle time:** time from PR opened to PR merged
+- **Defect density:** bugs found post-merge per sprint
+- **Documentation coverage:** percentage of functions/modules with adequate documentation
+- **Test coverage:** line/branch coverage by module
+
+### Pilot Outcome Metrics
+Measured at 4, 8, and 12 weeks after training for the pilot cohort vs. the control:
+- Same metrics as baseline, plus:
+- **Engineer satisfaction:** brief anonymous pulse (do you feel more or less productive with AI assistance?)
+- **Code review feedback:** are reviewers noting quality differences?
+
+### What to Do With the Numbers
+Publish them internally. Not selectively — all of them, including the metrics that are flat or mixed. The credibility of the initiative depends on honest reporting. A transformation that cherry-picks its evidence will be found out, and the credibility damage is severe and lasting.
+
+---
+
+## 7. Classified Environment Strategy
+
+This section requires significant refinement during Phase 0 reconnaissance. What follows is the preliminary framework.
+
+### NIPR (Unclassified / CUI)
+Commercial AI tools may be usable with appropriate controls:
+- Tool must be FedRAMP-authorized (High, where required by program ATO)
+- Data handling verified: no CUI input into tools not cleared for CUI
+- Approved through IT/ISSO via existing procurement vehicles where possible
+- GitHub Copilot, Tabnine, Amazon CodeWhisperer are common candidates — verify FedRAMP status and data handling policies before recommending
+
+### SIPR (Secret) and JWICS (TS/SCI)
+Commercial cloud AI tools are not appropriate. Local/on-premise model deployment only:
+- **Ollama** with open-source models (Llama 3, Code Llama, Mistral, StarCoder) on approved hardware
+- **Azure Government OpenAI** — if program has Azure Government presence and appropriate ATO
+- **AWS GovCloud Bedrock** — similar; verify per-program ATO
+- All model deployments require approval through the program ATO process
+
+The classified environment strategy is the most complex part of this transformation. Do not make commitments here before Phase 0 reconnaissance is complete.
+
+---
+
+## 8. Quick Reference — The First 90 Days
+
+| Week | Priority Action |
+|------|----------------|
+| 1–2 | Meet every engineering lead. Listen. Don't pitch. |
+| 2–3 | Find the early adopters. Confirm their interest quietly. |
+| 3–4 | Get the approved tool inventory from IT/ISSO. Map classification posture. |
+| 4–6 | Run Phase 0 report for Nugent/Gelyana/Mak. |
+| 6–8 | Stand up governance framework for the pilot. |
+| 8–10 | Begin Level 0 orientation with pilot cohort. |
+| 10–12 | Level 1 training with pilot cohort. Measure baseline first. |
+
+---
+
+*Update this document after the first cohort completes Level 1 training. Revise team segmentation estimates based on actual team composition observed in Phase 0.*


### PR DESCRIPTION
## Summary\n- recover stashed untracked workstream artifacts to a dedicated branch\n- add accelint context docs and placeholder Industry file for later follow-up\n\n## Notes\n- larger planning/codex/docs content was already merged into integration in prior PRs\n- this PR intentionally parks remaining recovered context for later re-engagement