### PR TITLE
feat(A0-mopup): magic test prefix, E2E and Flutter widget tests, audit_log cascade fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,6 +64,7 @@ npm-debug.log*
 # Testing
 coverage/
 .nyc_output/
+test_logs/
 
 # Secrets (never commit!)
 *.pem

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -526,10 +526,16 @@ cd packages/admin-app && flutter run -d chrome
 ```
 
 ### DevCode system (magic test phone prefix)
-Phone numbers starting with `+1555555` (NANPA reserved fictional prefix) always use local devCode verification, bypassing Twilio. This allows:
+Phone numbers starting with `+1555555` (NANPA reserved fictional prefix) use local devCode verification, bypassing Twilio. Controlled by `ENABLE_MAGIC_TEST_PREFIX`:
+- **`ENABLE_MAGIC_TEST_PREFIX=true`** (dev k8s via dev.env): magic prefix active
+- **`ENABLE_MAGIC_TEST_PREFIX=false`** (prod k8s via prod.env): magic prefix hard-blocked
+- **`NODE_ENV=test`** (local Jest): magic prefix active regardless of env var
+- **Not set / unrecognised value**: magic prefix inactive (safe default)
+
+Use cases:
 - **Automated tests:** Run without Twilio credentials
 - **Dev environment:** Use real Twilio for manual testing with real phones, use magic prefix for scripted tests
-- **Production:** Magic prefix is blocked (returns false from `isTestPhone()`)
+- **Production:** Hard-blocked — `isTestPhone()` returns false when `ENABLE_MAGIC_TEST_PREFIX=false`
 
 **Magic prefix behavior:**
 1. `POST /auth/request-code` with `+1555555xxxx` → generates 6-digit code, stores in `verification_codes`, returns `{ devCode: "123456" }`
@@ -554,7 +560,7 @@ Phone numbers starting with `+1555555` (NANPA reserved fictional prefix) always 
 
 2. **GoRouter singleton:** `GoRouter` must be created once in `initState()` of the app widget, NOT inside a `Consumer<AppState>` that rebuilds on every `notifyListeners()`. GoRouter's `refreshListenable` parameter handles auth state re-evaluation.
 
-3. **Magic test phone prefix:** Phone numbers `+1555555xxxx` always use local devCode verification (bypasses Twilio). Blocked in production. Used by automated tests.
+3. **Magic test phone prefix:** Phone numbers `+1555555xxxx` use local devCode verification when `ENABLE_MAGIC_TEST_PREFIX=true` (dev k8s) or `NODE_ENV=test` (local Jest). Hard-blocked when `ENABLE_MAGIC_TEST_PREFIX=false` (prod k8s). Do not assume it's active just because you're not in production — the env var must be explicitly set.
 
 4. **User deletion cascade:** `DELETE FROM users WHERE id = $1` cascades to all related tables. But you MUST delete `verification_codes` separately first (keyed by phone, not user ID).
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -525,19 +525,23 @@ cd packages/social-app && flutter run
 cd packages/admin-app && flutter run -d chrome
 ```
 
-### DevCode system (explicit fallback mode)
-When `AUTH_ALLOW_DEV_OTP_FALLBACK=true` **and** Twilio Verify is unavailable:
-1. Backend generates its own 6-digit code, stores it in `verification_codes` table
-2. Returns `{ message: "Verification code sent", devCode: "123456" }` on `/auth/request-code`
-3. Flutter `phone_entry_screen` captures `devCode` from response
-4. Passes it to `sms_verify_screen` which auto-fills the code field
-5. Auto-submits after a short delay
+### DevCode system (magic test phone prefix)
+Phone numbers starting with `+1555555` (NANPA reserved fictional prefix) always use local devCode verification, bypassing Twilio. This allows:
+- **Automated tests:** Run without Twilio credentials
+- **Dev environment:** Use real Twilio for manual testing with real phones, use magic prefix for scripted tests
+- **Production:** Magic prefix is blocked (returns false from `isTestPhone()`)
 
-When Twilio Verify is available (default behavior):
-- Twilio Verify API handles code generation, delivery, and verification
-- No codes stored in local DB; no `devCode` in response
+**Magic prefix behavior:**
+1. `POST /auth/request-code` with `+1555555xxxx` → generates 6-digit code, stores in `verification_codes`, returns `{ devCode: "123456" }`
+2. `POST /auth/verify-code` with `+1555555xxxx` → checks local DB, not Twilio Verify
 
-When Twilio Verify is unavailable and fallback is not enabled (default), `/auth/request-code` and `/auth/verify-code` return 503.
+**Real phone behavior (when Twilio configured):**
+1. `POST /auth/request-code` → Twilio Verify sends SMS, no `devCode` in response
+2. `POST /auth/verify-code` → Twilio Verify validates code
+
+**Fallback (no Twilio, real phone):**
+- If `AUTH_ALLOW_DEV_OTP_FALLBACK=true`: uses local devCode path
+- Otherwise: returns 503 "SMS verification is unavailable"
 
 ### iOS setup
 - Deployment target: iOS 14.0
@@ -550,7 +554,7 @@ When Twilio Verify is unavailable and fallback is not enabled (default), `/auth/
 
 2. **GoRouter singleton:** `GoRouter` must be created once in `initState()` of the app widget, NOT inside a `Consumer<AppState>` that rebuilds on every `notifyListeners()`. GoRouter's `refreshListenable` parameter handles auth state re-evaluation.
 
-3. **Twilio Verify default:** OTP uses Twilio Verify by default. Local `devCode` fallback only works when `AUTH_ALLOW_DEV_OTP_FALLBACK=true`.
+3. **Magic test phone prefix:** Phone numbers `+1555555xxxx` always use local devCode verification (bypasses Twilio). Blocked in production. Used by automated tests.
 
 4. **User deletion cascade:** `DELETE FROM users WHERE id = $1` cascades to all related tables. But you MUST delete `verification_codes` separately first (keyed by phone, not user ID).
 

--- a/docs/ai prompts/Dev Code Review Prompt.md
+++ b/docs/ai prompts/Dev Code Review Prompt.md
@@ -1,0 +1,31 @@
+## Dev Code Review — Sanity Check
+
+Run this in the track agent (same Copilot window doing the implementation) before opening a PR. Not a full adversarial review — just a quick self-check pass on the code you just wrote.
+
+---
+
+Review the changes in the current working branch against `integration`:
+
+```bash
+git diff integration...HEAD -- packages/
+```
+
+Check for:
+
+1. **SQL injection** — any string interpolation in raw SQL queries? All user input must use parameterized queries (`$1`, `$2`, etc.).
+
+2. **Auth gaps** — are any new routes missing `authenticate`, `authenticateAdmin`, or `requireAdmin` middleware where they should have it?
+
+3. **snake_case JSON** — do any new Dart models use `@JsonSerializable()` without `fieldRename: FieldRename.snake`? (Exception: `AdminUser` which intentionally uses camelCase.)
+
+4. **Dead code / TODOs** — any `TODO`, `FIXME`, or commented-out blocks left in? List them; decide if they should be removed or tracked as issues.
+
+5. **Error handling at boundaries** — are user inputs (API request bodies, query params) validated with Zod before touching the DB? No validation needed for internal calls.
+
+6. **Obvious logic errors** — wrong variable used, off-by-one, condition inverted, early return missing.
+
+7. **Test coverage gap** — did you add a new route, model, or critical code path with no corresponding test? Note it.
+
+---
+
+Output: a short bulleted list of anything found. "Nothing found" is a valid result. Do not fix anything — flag only. The PR Copilot review in GitHub will do a deeper pass.

--- a/docs/codex/track-X/X1-schema-consolidation.md
+++ b/docs/codex/track-X/X1-schema-consolidation.md
@@ -1,0 +1,209 @@
+# X1 — Schema Consolidation
+
+**Track:** X (Exception / Operational)
+**Model:** control-agent (single-model, no A/B)
+**Effort:** Small
+**Depends on:** A0 merged to `integration`
+**Status:** ⬜ Not started
+
+---
+
+## Objective
+
+Collapse migrations `001` through `007` into a single new `001_baseline_schema.sql` that represents the full current schema. Archive the original incremental files. This is a pure restructuring — no schema changes, no data changes, no new features.
+
+After X1, the migrations folder will have exactly one file: `001_baseline_schema.sql`. Future migrations start at `002_*.sql`.
+
+---
+
+## Rationale
+
+Seven incremental migrations have accumulated since project start. Each is correct individually but together they represent archaeological history, not a useful starting point. Before the next round of schema-changing tracks (C1, C2, C3, etc.) adds more, consolidate now while the baseline is stable.
+
+This must happen **after A0** (which fixes audit_log cascade and adds test infrastructure) and **before** any track that adds new migrations.
+
+---
+
+## Execution Plan
+
+### Phase 1 — Capture current schema
+
+**Step 1: Port-forward to dev RDS**
+```bash
+./scripts/pf-db.sh --env dev start
+```
+
+**Step 2: pg_dump schema-only from dev RDS** (which has all 7 migrations applied)
+```bash
+pg_dump \
+  --schema-only \
+  --no-owner \
+  --no-acl \
+  --no-privileges \
+  -h 127.0.0.1 \
+  -p 5433 \
+  -U postgres \
+  -d industrynight \
+  -f /tmp/schema_dump_x1.sql
+```
+
+**Step 3: Clean the dump**
+Edit `/tmp/schema_dump_x1.sql` to remove:
+- `pg_dump` header comment block
+- `SET` statements (`SET client_encoding`, `SET standard_conforming_strings`, etc.)
+- `SELECT pg_catalog.set_config(...)` lines
+- Any `--` comment lines referencing specific object names (optional — keep schema-level comments)
+- The `_migrations` table DDL (this table is managed by `migrate.js`, not by the migration files themselves)
+
+The result should be clean DDL: enums → tables → indexes → triggers → functions, in dependency order.
+
+**Step 4: Add file header**
+Prepend:
+```sql
+-- 001_baseline_schema.sql
+-- Consolidated baseline schema (replaces 001–007 incremental migrations)
+-- Generated from dev RDS as of X1 execution on [DATE]
+-- Do not edit incrementally — create 002_*.sql for future changes
+```
+
+---
+
+### Phase 2 — Replace migration files
+
+**Step 5: Archive old migrations**
+```bash
+cd packages/database/migrations
+mkdir -p archive
+mv 001_baseline_schema.sql archive/001_baseline_schema_original.sql
+mv 002_event_images.sql archive/
+mv 003_customers_products.sql archive/
+mv 004_drop_event_image_url.sql archive/
+mv 005_posh_orders.sql archive/
+mv 006_discount_redemptions.sql archive/
+mv 007_audit_log_cascade.sql archive/
+```
+
+*(Adjust filenames to match actual files — check `packages/database/migrations/` before running.)*
+
+**Step 6: Place new consolidated file**
+```bash
+cp /tmp/schema_dump_x1.sql packages/database/migrations/001_baseline_schema.sql
+```
+
+**Step 7: Update `scripts/migrate.js` if needed**
+Verify `migrate.js` reads all `.sql` files in the migrations folder sorted alphanumerically. No change needed if it already does this — the new `001_baseline_schema.sql` will be picked up automatically.
+
+---
+
+### Phase 3 — Validate locally
+
+**Step 8: Teardown and rebuild local Docker postgres**
+```bash
+# Stop any running api containers, then:
+docker rm -f pg-local 2>/dev/null || true
+docker run -d \
+  --name pg-local \
+  -e POSTGRES_PASSWORD=postgres \
+  -e POSTGRES_DB=industrynight \
+  -p 5432:5432 \
+  postgres:15
+sleep 3
+```
+
+**Step 9: Apply new consolidated migration only**
+```bash
+DB_HOST=localhost DB_PORT=5432 DB_NAME=industrynight DB_USER=postgres \
+DB_PASSWORD=postgres DB_SSL=false \
+node scripts/migrate.js --skip-k8s
+```
+
+Expected output: `[migrate] Applied: 001_baseline_schema.sql` — no other files.
+
+**Step 10: Run full local closeout suite**
+```bash
+./scripts/closeout-test.sh X1 --local-only
+```
+
+Expected: Phase 1 (Jest 145/145), Phase 2 (Flutter 30/30), Phase 3 (E2E 25/25).
+
+If any test fails, the dump or cleanup step introduced a schema difference. Compare failing migration with archived files.
+
+---
+
+### Phase 4 — AWS validation
+
+**Step 11: Apply to dev RDS**
+Since dev RDS already has all 7 migrations applied, the `_migrations` table already tracks them. The consolidated file is a **drop-in replacement** for fresh environments only — no need to re-apply to dev RDS.
+
+To validate end-to-end on AWS (full rebuild):
+```bash
+./scripts/closeout-test.sh X1 --env dev
+```
+
+This runs phases 4–7: migrate RDS → deploy EKS → E2E → smoke.
+
+---
+
+### Phase 5 — PR and merge
+
+**Step 12: Commit and push**
+```bash
+git add packages/database/migrations/
+git commit -m "feat(X1): consolidate migrations 001-007 into new 001_baseline_schema.sql"
+git push -u origin feature/X1-schema-consolidation
+```
+
+**Step 13: Open PR → integration**
+```bash
+gh pr create \
+  --base integration \
+  --head feature/X1-schema-consolidation \
+  --title "feat(X1): schema consolidation - collapse 001-007 into single baseline" \
+  --body "Operational track X1. No schema changes — pure restructuring. Verified by 197 tests (145 Jest + 30 Flutter + 25 E2E) plus AWS smoke."
+```
+
+**Step 14: After merge — update tracker and write decision log**
+Update [docs/codex/tracks.md](../tracks.md): X1 row → `✅ Merged`.
+
+Create `docs/codex/log/X1-control-decision.md` with:
+- Migration files archived and new filename
+- Closeout test results summary (phases 1–7, pass counts)
+- Raw log filename (`test_logs/X1_closeout_test_YYYY-MM-DD_HHMMSS.log` — git-ignored, local only)
+- Merge SHA and date
+
+The tracker "Log" column points to the decision doc; the decision doc references the raw log by name for local auditability.
+
+---
+
+## Validation Criteria
+
+| Check | Pass Condition |
+|-------|---------------|
+| `migrate.js` on clean DB | Only `001_baseline_schema.sql` applied, no errors |
+| Jest suite | 145/145 passing |
+| Flutter tests | 30/30 passing |
+| Local E2E | 25/25 passing |
+| AWS migrate | No errors on dev RDS re-deploy |
+| AWS smoke | All endpoints respond correctly |
+| `_migrations` tracking | On fresh DB: exactly 1 row (`001_baseline_schema.sql`) |
+| Archive intact | 002–007 all present in `migrations/archive/` |
+
+---
+
+## Risk Notes
+
+- **Do not change any column names, types, or constraints.** This is a pure snapshot — if the dump differs from what the app expects, revert.
+- **Check enum order.** PostgreSQL dumps enums before tables. Ensure all enum types used in table columns appear earlier in the file.
+- **Triggers and functions.** `pg_dump --schema-only` includes trigger functions (`plpgsql`). Verify these appear before the `CREATE TRIGGER` statements that reference them.
+- **Dev RDS is not affected** by this PR — it already has the schema. Only fresh environments (new dev spins, CI, teardown+rebuild) use the new file.
+
+---
+
+## Branch
+
+```
+integration
+└── feature/X1-schema-consolidation
+```
+
+No `-claude` / `-gpt` suffixes. No adversarial review. Control agent owns execution start to finish.

--- a/docs/codex/tracks.md
+++ b/docs/codex/tracks.md
@@ -162,6 +162,18 @@ TODAY — Start all three in parallel (all are ⚡ A/B):
 
 ---
 
+## Track X — Exception / Operational Tracks
+
+**Purpose:** Infrastructure, consolidation, and operational interruptions that don't fit the product track model. Single-model (no A/B), control-agent-owned, verified by infrastructure tests rather than adversarial review.
+
+| Prompt | Title | Model | A/B | Effort | Depends On |
+|--------|-------|-------|-----|--------|------------|
+| X1 | Schema Consolidation | control-agent | — | Small | A0 merged |
+
+**Track X completion:** Ongoing — new X-tracks added as operational needs arise.
+
+---
+
 ## Post-Track Completion Gate (Preproduction)
 
 When all tracks are complete (preproduction), execute this finalization sequence:
@@ -183,7 +195,8 @@ Update this table as prompts complete.
 | Prompt | A/B | Status | Winner | Log | Review | Notes |
 |--------|-----|--------|--------|-----|--------|-------|
 | C0 | ⚡ | ✅ Merged | Claude | docs/codex/log/C0-control-decision.md | docs/codex/reviews/C0-adversarial-review.md | Winner-only control-session apply executed on AWS dev; C0 schema gate complete |
-| A0 | ⚡ | 🟠 Under adversarial review | GPT | — | docs/codex/reviews/A0-adversarial-review.md | Winner identified; carry-forward execution in progress |
+| A0 | ⚡ | 🟠 PR #54 open | GPT | docs/codex/log/A0-control-decision.md | docs/codex/reviews/A0-adversarial-review.md | Winner identified; carry-forward execution complete; PR open awaiting merge |
+| X1 | — | ⬜ Not started | N/A | docs/codex/log/X1-control-decision.md | — | Waiting for A0 merge; collapse 001–007 → new 001_baseline_schema.sql |
 | B0 | ⚡ | ⬜ Not started | — | — | — | |
 | C1 | — | ⬜ Not started | — | — | — | Waiting for C0 |
 | C2 | — | ⬜ Not started | — | — | — | Waiting for C0 |

--- a/infrastructure/k8s/deployment.yaml
+++ b/infrastructure/k8s/deployment.yaml
@@ -30,6 +30,8 @@ spec:
               value: "production"
             - name: AUDIT_ENVIRONMENT
               value: "__ENVIRONMENT__"
+            - name: ENABLE_MAGIC_TEST_PREFIX
+              value: "__ENABLE_MAGIC_TEST_PREFIX__"
             - name: PORT
               value: "3000"
             - name: AWS_REGION

--- a/packages/api/jest.config.ts
+++ b/packages/api/jest.config.ts
@@ -5,9 +5,10 @@ const config: Config = {
   preset: 'ts-jest',
   testEnvironment: 'node',
 
-  // Test files live in tests/ directory
+  // Test files live in tests/ directory (exclude tests/e2e/ — those use jest.e2e.config.ts)
   roots: ['<rootDir>/tests'],
   testMatch: ['**/*.test.ts'],
+  testPathIgnorePatterns: ['/node_modules/', '<rootDir>/tests/e2e/'],
 
   // Global setup/teardown — starts and stops the PostgreSQL container
   globalSetup: '<rootDir>/tests/setup.ts',

--- a/packages/api/jest.e2e.config.ts
+++ b/packages/api/jest.e2e.config.ts
@@ -1,0 +1,35 @@
+/**
+ * Jest config for E2E tests against deployed API.
+ *
+ * Key differences from jest.config.ts (local tests):
+ *   - No globalSetup/teardown (no testcontainer needed)
+ *   - testMatch points to tests/e2e/
+ *   - runInBand: cleanup describe block must run last
+ *   - Longer timeout: real HTTP calls over network
+ *
+ * Usage:
+ *   API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e
+ */
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+
+  roots: ['<rootDir>/tests/e2e'],
+  testMatch: ['**/*.test.ts'],
+
+  // No container setup — hits real API
+  globalSetup: undefined,
+  globalTeardown: undefined,
+
+  // 30s timeout for real HTTP round-trips
+  testTimeout: 30000,
+
+  moduleFileExtensions: ['ts', 'js', 'json'],
+  transformIgnorePatterns: ['/node_modules/'],
+  forceExit: true,
+  verbose: true,
+};
+
+export default config;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -9,6 +9,7 @@
     "start": "node dist/index.js",
     "test": "jest",
     "test:watch": "jest --watch",
+    "test:e2e": "jest --config jest.e2e.config.ts --runInBand",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "typecheck": "tsc --noEmit"

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -24,6 +24,11 @@ import adminAuthRoutes from './routes/admin-auth';
 
 const app = express();
 
+// Trust one reverse-proxy hop (ALB/ingress) so rate limiting and request IP handling work correctly.
+if (config.nodeEnv !== 'test') {
+  app.set('trust proxy', 1);
+}
+
 if (!config.audit.enabled && config.nodeEnv !== 'test') {
   console.error('');
   console.error('!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!');

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -59,7 +59,7 @@ if (config.nodeEnv !== 'test') {
 }
 
 // Rate limiters (skipped in test — tests make many requests from a single IP)
-const isTest = config.nodeEnv === 'test';
+const isTest = config.nodeEnv === 'test' || process.env.ENABLE_MAGIC_TEST_PREFIX === 'true';
 
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -59,15 +59,26 @@ if (config.nodeEnv !== 'test') {
 }
 
 // Rate limiters (skipped in test — tests make many requests from a single IP)
-const isTest = config.nodeEnv === 'test' || process.env.ENABLE_MAGIC_TEST_PREFIX === 'true';
-
+//
+// authLimiter: in non-test environments, bypass only for magic-prefix phones
+// (+1555555xxxx) when ENABLE_MAGIC_TEST_PREFIX is set. All other callers are
+// rate-limited normally. This avoids disabling rate limiting globally in dev k8s.
+//
+// adminAuthLimiter: no magic-prefix bypass — admin login uses email, not phone.
 const authLimiter = rateLimit({
   windowMs: 15 * 60 * 1000, // 15 minutes
   max: 10,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many requests, please try again later' },
-  skip: isTest ? () => true : undefined,
+  skip: (req) => {
+    if (config.nodeEnv === 'test') return true;
+    if (process.env.ENABLE_MAGIC_TEST_PREFIX === 'true') {
+      const phone = req.body?.phone;
+      return typeof phone === 'string' && phone.startsWith('+1555555');
+    }
+    return false;
+  },
 });
 
 const adminAuthLimiter = rateLimit({
@@ -76,7 +87,7 @@ const adminAuthLimiter = rateLimit({
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: 'Too many login attempts, please try again later' },
-  skip: isTest ? () => true : undefined,
+  skip: () => config.nodeEnv === 'test',
 });
 
 // Health check with DB connectivity verification

--- a/packages/api/src/config/database.ts
+++ b/packages/api/src/config/database.ts
@@ -2,7 +2,11 @@ import { Pool } from 'pg';
 import { config } from './env';
 
 // SSL: required in dev/prod (defense in depth), disabled in test (testcontainers has no SSL)
-const sslConfig = config.nodeEnv === 'test' ? false : { rejectUnauthorized: false };
+// DB_SSL=false also disables SSL for local Docker postgres used in closeout-test.sh
+const sslConfig =
+  config.nodeEnv === 'test' || process.env.DB_SSL === 'false'
+    ? false
+    : { rejectUnauthorized: false };
 
 const pool = new Pool(
   config.database.url

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -5,6 +5,9 @@ const PORT = config.port;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);
   console.log(`Environment: ${config.nodeEnv}`);
+  if (process.env.ENABLE_MAGIC_TEST_PREFIX === 'true') {
+    console.warn('[SECURITY] ENABLE_MAGIC_TEST_PREFIX=true — magic test phone prefix is active. Ensure this is intentional for this environment.');
+  }
 });
 
 export default app;

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -19,13 +19,16 @@ function phoneDigits(phone: string): string {
 /**
  * Magic test phone prefix: +1555555xxxx
  * - Always uses local devCode verification (bypasses Twilio)
- * - Blocked in production for security
+ * - Enabled when ENABLE_MAGIC_TEST_PREFIX=true OR NODE_ENV=test
+ * - NOT enabled by NODE_ENV=production alone — requires explicit opt-in for dev clusters
  * - Used by automated tests and local development
  */
 function isTestPhone(phone: string): boolean {
-  if (process.env.NODE_ENV === 'production') {
-    return false;
-  }
+  // Enabled if explicitly opted in (dev k8s) OR running under Jest (local)
+  const enabled =
+    process.env.ENABLE_MAGIC_TEST_PREFIX === 'true' ||
+    process.env.NODE_ENV === 'test';
+  if (!enabled) return false;
   return phone.startsWith('+1555555');
 }
 

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -20,10 +20,13 @@ function phoneDigits(phone: string): string {
  * Magic test phone prefix: +1555555xxxx
  * - Always uses local devCode verification (bypasses Twilio)
  * - Enabled when ENABLE_MAGIC_TEST_PREFIX=true OR NODE_ENV=test
- * - NOT enabled by NODE_ENV=production alone — requires explicit opt-in for dev clusters
+ * - Hard-disabled when ENABLE_MAGIC_TEST_PREFIX=false (explicitly set in prod.env)
+ * - dev k8s runs NODE_ENV=production; use ENABLE_MAGIC_TEST_PREFIX to control, not NODE_ENV
  * - Used by automated tests and local development
  */
 function isTestPhone(phone: string): boolean {
+  // Hard guard: explicitly disabled in production (prod.env sets ENABLE_MAGIC_TEST_PREFIX=false)
+  if (process.env.ENABLE_MAGIC_TEST_PREFIX === 'false') return false;
   // Enabled if explicitly opted in (dev k8s) OR running under Jest (local)
   const enabled =
     process.env.ENABLE_MAGIC_TEST_PREFIX === 'true' ||
@@ -134,7 +137,9 @@ router.post('/request-code', validate(requestCodeSchema), async (req, res, next)
       statusCode: 200,
       metadata: {
         flow: 'request_code',
-        provider: verifyAvailable ? 'twilio_verify' : (allowDevOtpFallback ? 'local_dev' : 'unavailable'),
+        provider: useLocalCode
+          ? (isTestPhone(phone) ? 'magic_test_prefix' : 'local_dev')
+          : 'twilio_verify',
       },
     });
   } catch (error) {

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -16,6 +16,19 @@ function phoneDigits(phone: string): string {
   return phone.replace(/\D/g, '');
 }
 
+/**
+ * Magic test phone prefix: +1555555xxxx
+ * - Always uses local devCode verification (bypasses Twilio)
+ * - Blocked in production for security
+ * - Used by automated tests and local development
+ */
+function isTestPhone(phone: string): boolean {
+  if (process.env.NODE_ENV === 'production') {
+    return false;
+  }
+  return phone.startsWith('+1555555');
+}
+
 async function reconcilePoshOrdersForUser(userId: string, phone: string): Promise<{ linkedOrders: number; createdTickets: number }> {
   const fullDigits = phoneDigits(phone);
   const localDigits = fullDigits.length > 10 ? fullDigits.slice(-10) : fullDigits;
@@ -86,12 +99,9 @@ router.post('/request-code', validate(requestCodeSchema), async (req, res, next)
   try {
     const { phone } = req.body;
     const allowDevOtpFallback = config.auth.allowDevOtpFallback;
+    const useLocalCode = isTestPhone(phone) || (!verifyAvailable && allowDevOtpFallback);
 
-    if (verifyAvailable) {
-      // Use Twilio Verify — it handles code generation, storage, and delivery
-      await sendVerification(phone);
-      res.json({ message: 'Verification code sent' });
-    } else if (allowDevOtpFallback) {
+    if (useLocalCode) {
       // Explicit dev fallback mode: generate and store code locally
       const code = generateVerificationCode();
       const expiresAt = new Date(Date.now() + 10 * 60 * 1000); // 10 minutes
@@ -105,6 +115,10 @@ router.post('/request-code', validate(requestCodeSchema), async (req, res, next)
 
       console.log(`[SMS-DEV] Verification code generated for ****${phone.slice(-4)}`);
       res.json({ message: 'Verification code sent', devCode: code });
+    } else if (verifyAvailable) {
+      // Use Twilio Verify — it handles code generation, storage, and delivery
+      await sendVerification(phone);
+      res.json({ message: 'Verification code sent' });
     } else {
       throw new AppError(503, 'SMS verification is unavailable. Twilio Verify is required.');
     }
@@ -148,14 +162,9 @@ router.post('/verify-code', validate(verifyCodeSchema), async (req, res, next) =
   try {
     const { phone, code } = req.body;
     const allowDevOtpFallback = config.auth.allowDevOtpFallback;
+    const useLocalCode = isTestPhone(phone) || (!verifyAvailable && allowDevOtpFallback);
 
-    if (verifyAvailable) {
-      // Use Twilio Verify to check the code
-      const approved = await checkVerification(phone, code);
-      if (!approved) {
-        throw new BadRequestError('Invalid verification code');
-      }
-    } else if (allowDevOtpFallback) {
+    if (useLocalCode) {
       // Explicit dev fallback mode: check code from our database
       const storedCode = await queryOne<{ code: string; expires_at: Date }>(
         'SELECT code, expires_at FROM verification_codes WHERE phone = $1',
@@ -172,6 +181,12 @@ router.post('/verify-code', validate(verifyCodeSchema), async (req, res, next) =
 
       // Delete used code
       await query('DELETE FROM verification_codes WHERE phone = $1', [phone]);
+    } else if (verifyAvailable) {
+      // Use Twilio Verify to check the code
+      const approved = await checkVerification(phone, code);
+      if (!approved) {
+        throw new BadRequestError('Invalid verification code');
+      }
     } else {
       throw new AppError(503, 'SMS verification is unavailable. Twilio Verify is required.');
     }

--- a/packages/api/src/routes/auth.ts
+++ b/packages/api/src/routes/auth.ts
@@ -400,6 +400,9 @@ router.post('/logout', authenticate, async (req, res) => {
 router.get('/me', authenticate, async (req, res, next) => {
   try {
     const user = await queryOne('SELECT * FROM users WHERE id = $1', [req.user!.userId]);
+    if (!user) {
+      throw new NotFoundError('User not found');
+    }
     res.json({ user });
   } catch (error) {
     next(error);

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -284,7 +284,7 @@ describe('Migration 007: audit_log immutability & admin cascade fix', () => {
     const insertRes = await pool.query(
       `INSERT INTO audit_log
          (action, entity_type, entity_id, actor_type, actor_id, result, request_id)
-       VALUES ('update', 'user', $1, 'user', $1, 'success', gen_random_uuid())
+       VALUES ('update', 'user', $1, 'user', $1, 'success', uuid_generate_v4())
        RETURNING id`,
       [user.id]
     );

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -221,3 +221,124 @@ describe('Security Audit Logging', () => {
     });
   });
 });
+
+// ─── Migration 007 Regression Tests ──────────────────────────────────────────
+//
+// Validates the two bugs fixed in migration 007:
+//
+// Bug 1: DELETE FROM admin_users would 500 because the audit_log trigger
+//        failed to promote actor_type → 'system' in the admin_actor_id cascade
+//        path (migration 006 only NULLed admin_actor_id, leaving actor_type='admin',
+//        which satisfies none of the ck_audit_log_actor_identity branches).
+//
+// Bug 2: A crafted UPDATE on audit_log that changed non-FK columns alongside
+//        a FK-null could theoretically bypass the subset-column check in
+//        migrations 005/006. Migration 007 hardens this with a full-row
+//        NEW IS DISTINCT FROM OLD comparison.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('Migration 007: audit_log immutability & admin cascade fix', () => {
+  it('deleting an admin user promotes audit_log actor_type to system (bug 1 fix)', async () => {
+    const pool = getTestPool();
+
+    // Create an admin user and a social user to act as the entity.
+    const admin = await createAdminUser();
+    const user = await createUser();
+
+    // Insert an audit_log row with actor_type='admin' and admin_actor_id set.
+    const insertRes = await pool.query(
+      `INSERT INTO audit_log
+         (action, entity_type, entity_id, actor_type, admin_actor_id, result, request_id)
+       VALUES ('update', 'user', $1, 'admin', $2, 'success', gen_random_uuid())
+       RETURNING id`,
+      [user.id, admin.id]
+    );
+    const logId: string = insertRes.rows[0].id;
+
+    // This DELETE should NOT throw — migration 007 ensures the cascade is
+    // permitted and that actor_type is promoted to 'system'.
+    await expect(
+      pool.query(`DELETE FROM admin_users WHERE id = $1`, [admin.id])
+    ).resolves.not.toThrow();
+
+    // Verify the audit_log row was correctly tombstoned.
+    const auditRes = await pool.query(
+      `SELECT actor_type, actor_id, admin_actor_id FROM audit_log WHERE id = $1`,
+      [logId]
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      actor_type: 'system',
+      actor_id: null,
+      admin_actor_id: null,
+    });
+  });
+
+  it('deleting a social user promotes audit_log actor_type to system (existing user cascade path)', async () => {
+    const pool = getTestPool();
+
+    // Create a social user.
+    const user = await createUser();
+
+    // Insert an audit_log row with actor_type='user' and actor_id set.
+    const insertRes = await pool.query(
+      `INSERT INTO audit_log
+         (action, entity_type, entity_id, actor_type, actor_id, result, request_id)
+       VALUES ('update', 'user', $1, 'user', $1, 'success', gen_random_uuid())
+       RETURNING id`,
+      [user.id]
+    );
+    const logId: string = insertRes.rows[0].id;
+
+    // Manually delete the verification_code first (required by schema — phone PK).
+    await pool.query(`DELETE FROM verification_codes WHERE phone = $1`, [user.phone]);
+
+    // DELETE should not throw.
+    await expect(
+      pool.query(`DELETE FROM users WHERE id = $1`, [user.id])
+    ).resolves.not.toThrow();
+
+    // Verify tombstone.
+    const auditRes = await pool.query(
+      `SELECT actor_type, actor_id, admin_actor_id FROM audit_log WHERE id = $1`,
+      [logId]
+    );
+
+    expect(auditRes.rows).toHaveLength(1);
+    expect(auditRes.rows[0]).toMatchObject({
+      actor_type: 'system',
+      actor_id: null,
+      admin_actor_id: null,
+    });
+  });
+
+  it('rejects a direct UPDATE on audit_log that mutates non-FK columns alongside a FK null (bug 2 fix)', async () => {
+    const pool = getTestPool();
+
+    const admin = await createAdminUser();
+    const user = await createUser();
+
+    // Insert a baseline audit_log row.
+    const insertRes = await pool.query(
+      `INSERT INTO audit_log
+         (action, entity_type, entity_id, actor_type, admin_actor_id, result, request_id)
+       VALUES ('update', 'user', $1, 'admin', $2, 'success', gen_random_uuid())
+       RETURNING id`,
+      [user.id, admin.id]
+    );
+    const logId: string = insertRes.rows[0].id;
+
+    // A crafted UPDATE that NULLs admin_actor_id (mimicking cascade) BUT also
+    // changes metadata — should be rejected by the full-row comparison.
+    await expect(
+      pool.query(
+        `UPDATE audit_log
+           SET admin_actor_id = NULL,
+               actor_type = 'system',
+               metadata = '{"tampered": true}'
+         WHERE id = $1`,
+        [logId]
+      )
+    ).rejects.toThrow('audit_log is immutable');
+  });
+});

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -322,7 +322,7 @@ describe('Migration 007: audit_log immutability & admin cascade fix', () => {
     const insertRes = await pool.query(
       `INSERT INTO audit_log
          (action, entity_type, entity_id, actor_type, admin_actor_id, result, request_id)
-       VALUES ('update', 'user', $1, 'admin', $2, 'success', gen_random_uuid())
+       VALUES ('update', 'user', $1, 'admin', $2, 'success', uuid_generate_v4())
        RETURNING id`,
       [user.id, admin.id]
     );

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -41,7 +41,7 @@ describe('Security Audit Logging', () => {
   });
 
   it('logs verification_code_expired when verification code is expired', async () => {
-    const phone = '+15559999091';
+    const phone = '+15555550191';  // Magic test prefix
 
     const codeRes = await request(app)
       .post('/auth/request-code')

--- a/packages/api/tests/audit-security.test.ts
+++ b/packages/api/tests/audit-security.test.ts
@@ -248,7 +248,7 @@ describe('Migration 007: audit_log immutability & admin cascade fix', () => {
     const insertRes = await pool.query(
       `INSERT INTO audit_log
          (action, entity_type, entity_id, actor_type, admin_actor_id, result, request_id)
-       VALUES ('update', 'user', $1, 'admin', $2, 'success', gen_random_uuid())
+       VALUES ('update', 'user', $1, 'admin', $2, 'success', uuid_generate_v4())
        RETURNING id`,
       [user.id, admin.id]
     );

--- a/packages/api/tests/auth.test.ts
+++ b/packages/api/tests/auth.test.ts
@@ -4,9 +4,11 @@
  * Tests the complete social authentication lifecycle:
  *   request-code -> verify-code -> token issued -> refresh -> me -> logout -> delete
  *
- * In test mode, Twilio is not configured, so the auth system uses
- * dev mode (stores codes in verification_codes table, returns devCode
- * in the response). This is the same path used during local development.
+ * Uses magic test phone prefix (+1555555xxxx) which always routes to local
+ * devCode verification (bypasses Twilio). This allows:
+ *   - Automated tests to run without Twilio credentials
+ *   - Dev environment to use real Twilio for manual testing with real phones
+ *   - Magic prefix blocked in production for security
  *
  * Rate limiting is disabled in test mode (max: 0 = unlimited)
  * so tests can make unlimited requests without hitting 429.
@@ -27,11 +29,11 @@ describe('POST /auth/request-code', () => {
   it('sends a verification code and returns devCode in dev mode', async () => {
     const res = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15551234567' });
+      .send({ phone: '+15555550001' });
 
     expect(res.status).toBe(200);
     expect(res.body.message).toBe('Verification code sent');
-    // Dev mode returns the code for testing convenience
+    // Magic test prefix (+1555555xxxx) always returns devCode
     expect(res.body.devCode).toBeDefined();
     expect(res.body.devCode).toHaveLength(6);
   });
@@ -39,12 +41,12 @@ describe('POST /auth/request-code', () => {
   it('stores the code in verification_codes table', async () => {
     const res = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15551234567' });
+      .send({ phone: '+15555550001' });
 
     const pool = getTestPool();
     const result = await pool.query(
       'SELECT code FROM verification_codes WHERE phone = $1',
-      ['+15551234567']
+      ['+15555550001']
     );
 
     expect(result.rows).toHaveLength(1);
@@ -63,19 +65,19 @@ describe('POST /auth/request-code', () => {
     // First request
     const res1 = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15551234567' });
+      .send({ phone: '+15555550002' });
 
     // Second request (should overwrite via ON CONFLICT)
     const res2 = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15551234567' });
+      .send({ phone: '+15555550002' });
 
     expect(res1.body.devCode).not.toBe(res2.body.devCode);
 
     const pool = getTestPool();
     const result = await pool.query(
       'SELECT code FROM verification_codes WHERE phone = $1',
-      ['+15551234567']
+      ['+15555550002']
     );
     expect(result.rows).toHaveLength(1); // Only one row, not two
     expect(result.rows[0].code).toBe(res2.body.devCode);
@@ -87,34 +89,34 @@ describe('POST /auth/verify-code', () => {
     // Step 1: Request code
     const codeRes = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15559999001' });
+      .send({ phone: '+15555550101' });
 
     // Step 2: Verify code
     const verifyRes = await request(app)
       .post('/auth/verify-code')
-      .send({ phone: '+15559999001', code: codeRes.body.devCode });
+      .send({ phone: '+15555550101', code: codeRes.body.devCode });
 
     expect(verifyRes.status).toBe(200);
     expect(verifyRes.body.isNewUser).toBe(true);
     expect(verifyRes.body.accessToken).toBeDefined();
     expect(verifyRes.body.refreshToken).toBeDefined();
     expect(verifyRes.body.user).toBeDefined();
-    expect(verifyRes.body.user.phone).toBe('+15559999001');
+    expect(verifyRes.body.user.phone).toBe('+15555550101');
     expect(verifyRes.body.user.source).toBe('app');
   });
 
   it('returns existing user on subsequent verification', async () => {
     // Create user first
-    await createUser({ phone: '+15559999002', name: 'Returning User' });
+    await createUser({ phone: '+15555550102', name: 'Returning User' });
 
     // Request + verify code
     const codeRes = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15559999002' });
+      .send({ phone: '+15555550102' });
 
     const verifyRes = await request(app)
       .post('/auth/verify-code')
-      .send({ phone: '+15559999002', code: codeRes.body.devCode });
+      .send({ phone: '+15555550102', code: codeRes.body.devCode });
 
     expect(verifyRes.status).toBe(200);
     expect(verifyRes.body.isNewUser).toBe(false);
@@ -124,11 +126,11 @@ describe('POST /auth/verify-code', () => {
   it('rejects wrong verification code', async () => {
     await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15559999003' });
+      .send({ phone: '+15555550103' });
 
     const res = await request(app)
       .post('/auth/verify-code')
-      .send({ phone: '+15559999003', code: '000000' });
+      .send({ phone: '+15555550103', code: '000000' });
 
     expect(res.status).toBe(400);
     expect(res.body.message).toContain('Invalid');
@@ -137,16 +139,16 @@ describe('POST /auth/verify-code', () => {
   it('deletes the verification code after successful verification', async () => {
     const codeRes = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15559999004' });
+      .send({ phone: '+15555550104' });
 
     await request(app)
       .post('/auth/verify-code')
-      .send({ phone: '+15559999004', code: codeRes.body.devCode });
+      .send({ phone: '+15555550104', code: codeRes.body.devCode });
 
     const pool = getTestPool();
     const result = await pool.query(
       'SELECT * FROM verification_codes WHERE phone = $1',
-      ['+15559999004']
+      ['+15555550104']
     );
     expect(result.rows).toHaveLength(0);
   });
@@ -154,11 +156,11 @@ describe('POST /auth/verify-code', () => {
   it('updates last_login_at timestamp', async () => {
     const codeRes = await request(app)
       .post('/auth/request-code')
-      .send({ phone: '+15559999005' });
+      .send({ phone: '+15555550105' });
 
     const verifyRes = await request(app)
       .post('/auth/verify-code')
-      .send({ phone: '+15559999005', code: codeRes.body.devCode });
+      .send({ phone: '+15555550105', code: codeRes.body.devCode });
 
     expect(verifyRes.body.user.last_login_at).toBeDefined();
   });

--- a/packages/api/tests/e2e/client.ts
+++ b/packages/api/tests/e2e/client.ts
@@ -1,0 +1,106 @@
+/**
+ * E2E API Client
+ *
+ * Typed fetch wrapper for testing against deployed API endpoints.
+ * Handles auth headers, JSON parsing, and error extraction.
+ */
+
+import { getBaseUrl } from './config';
+
+export type ApiResponse<T = unknown> = {
+  status: number;
+  body: T;
+  headers: Record<string, string>;
+};
+
+export type AuthTokens = {
+  accessToken: string;
+  refreshToken: string;
+  user: Record<string, unknown>;
+  isNewUser?: boolean;
+};
+
+async function request<T>(
+  method: string,
+  path: string,
+  options: {
+    body?: unknown;
+    accessToken?: string;
+    refreshToken?: string;
+  } = {}
+): Promise<ApiResponse<T>> {
+  const url = `${getBaseUrl()}${path}`;
+  const headers: Record<string, string> = {
+    'Content-Type': 'application/json',
+  };
+
+  if (options.accessToken) {
+    headers['Authorization'] = `Bearer ${options.accessToken}`;
+  }
+
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: options.body ? JSON.stringify(options.body) : undefined,
+  });
+
+  let body: T;
+  const contentType = res.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    body = await res.json() as T;
+  } else {
+    body = await res.text() as unknown as T;
+  }
+
+  const headers2: Record<string, string> = {};
+  res.headers.forEach((v, k) => { headers2[k] = v; });
+
+  return { status: res.status, body, headers: headers2 };
+}
+
+export const api = {
+  get: <T>(path: string, accessToken?: string) =>
+    request<T>('GET', path, { accessToken }),
+
+  post: <T>(path: string, body: unknown, accessToken?: string) =>
+    request<T>('POST', path, { body, accessToken }),
+
+  patch: <T>(path: string, body: unknown, accessToken?: string) =>
+    request<T>('PATCH', path, { body, accessToken }),
+
+  delete: <T>(path: string, accessToken?: string) =>
+    request<T>('DELETE', path, { accessToken }),
+};
+
+/**
+ * Full auth flow: request-code → verify-code → return tokens.
+ * Uses magic test phone prefix so no real SMS is sent.
+ */
+export async function authenticateTestPhone(phone: string): Promise<AuthTokens> {
+  const codeRes = await api.post<{ message: string; devCode?: string }>(
+    '/auth/request-code',
+    { phone }
+  );
+
+  if (codeRes.status !== 200) {
+    throw new Error(`request-code failed: ${codeRes.status} ${JSON.stringify(codeRes.body)}`);
+  }
+
+  if (!codeRes.body.devCode) {
+    throw new Error(
+      'No devCode in response. Magic prefix may be blocked in this environment, ' +
+      'or NODE_ENV=production is set.'
+    );
+  }
+
+  const verifyRes = await api.post<AuthTokens>('/auth/verify-code', {
+    phone,
+    code: codeRes.body.devCode,
+  });
+
+  if (verifyRes.status !== 200) {
+    throw new Error(`verify-code failed: ${verifyRes.status} ${JSON.stringify(verifyRes.body)}`);
+  }
+
+  return verifyRes.body;
+}

--- a/packages/api/tests/e2e/client.ts
+++ b/packages/api/tests/e2e/client.ts
@@ -88,8 +88,8 @@ export async function authenticateTestPhone(phone: string): Promise<AuthTokens> 
 
   if (!codeRes.body.devCode) {
     throw new Error(
-      'No devCode in response. Magic prefix may be blocked in this environment, ' +
-      'or NODE_ENV=production is set.'
+      'No devCode in response. Magic test prefix may be disabled in this environment. ' +
+      'Ensure ENABLE_MAGIC_TEST_PREFIX=true is set (dev.env) or NODE_ENV=test (local Jest).'
     );
   }
 

--- a/packages/api/tests/e2e/config.ts
+++ b/packages/api/tests/e2e/config.ts
@@ -1,0 +1,28 @@
+/**
+ * E2E Test Configuration
+ *
+ * Reads API_BASE_URL from environment. Defaults to dev if not set.
+ * Run against deployed infrastructure:
+ *   API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e
+ */
+
+export function getBaseUrl(): string {
+  const url = process.env.API_BASE_URL;
+  if (!url) {
+    throw new Error(
+      'API_BASE_URL is required for E2E tests.\n' +
+      'Example: API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e'
+    );
+  }
+  return url.replace(/\/$/, ''); // strip trailing slash
+}
+
+/**
+ * Generate a unique test phone number using magic prefix.
+ * Uses timestamp to avoid collisions across concurrent or repeated runs.
+ * Format: +1555555XXXX (10 digits after country code)
+ */
+export function testPhone(suffix?: string): string {
+  const unique = suffix ?? String(Date.now()).slice(-4);
+  return `+1555555${unique.padStart(4, '0')}`;
+}

--- a/packages/api/tests/e2e/config.ts
+++ b/packages/api/tests/e2e/config.ts
@@ -19,10 +19,10 @@ export function getBaseUrl(): string {
 
 /**
  * Generate a unique test phone number using magic prefix.
- * Uses timestamp to avoid collisions across concurrent or repeated runs.
- * Format: +1555555XXXX (10 digits after country code)
+ * Uses a random 4-digit suffix to avoid collisions across concurrent or repeated runs.
+ * Format: +1555555XXXX (10 digits after country code — NANPA maximum)
  */
 export function testPhone(suffix?: string): string {
-  const unique = suffix ?? String(Date.now()).slice(-4);
+  const unique = suffix ?? String(Math.floor(Math.random() * 10000)).padStart(4, '0');
   return `+1555555${unique.padStart(4, '0')}`;
 }

--- a/packages/api/tests/e2e/config.ts
+++ b/packages/api/tests/e2e/config.ts
@@ -1,7 +1,7 @@
 /**
  * E2E Test Configuration
  *
- * Reads API_BASE_URL from environment. Defaults to dev if not set.
+ * Reads API_BASE_URL from environment. Required — throws if not set.
  * Run against deployed infrastructure:
  *   API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e
  */

--- a/packages/api/tests/e2e/e2e.test.ts
+++ b/packages/api/tests/e2e/e2e.test.ts
@@ -1,0 +1,249 @@
+/**
+ * E2E Tests — API against deployed infrastructure
+ *
+ * Runs against a real deployed API instance (dev or prod).
+ * Uses magic test phone prefix (+1555555xxxx) for auth flows
+ * so no real SMS is sent. Test user is created then deleted at the end.
+ *
+ * Usage:
+ *   API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e
+ *
+ * Notes:
+ *   - Tests run in band (sequentially) so cleanup runs last
+ *   - Each run generates a unique test phone to avoid collisions
+ *   - Shared auth tokens are established once and reused
+ *   - Read-only tests first, write tests last, cleanup at end
+ */
+
+import { api, authenticateTestPhone, type AuthTokens } from './client';
+import { getBaseUrl, testPhone } from './config';
+
+// Unique phone for this test run — prevents collision with parallel runs
+const TEST_PHONE = testPhone();
+
+// Shared auth state — populated once, reused across suites
+let auth: AuthTokens;
+
+// ─── Setup ──────────────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  console.log(`\nE2E target: ${getBaseUrl()}`);
+  console.log(`Test phone:  ${TEST_PHONE}\n`);
+});
+
+// ─── Health & Public Endpoints ───────────────────────────────────────────────
+
+describe('GET /health', () => {
+  it('returns 200 with status ok', async () => {
+    const res = await api.get<{ status: string; timestamp: string }>('/health');
+    expect(res.status).toBe(200);
+    expect(res.body.status).toBe('ok');
+    expect(res.body.timestamp).toBeDefined();
+    expect(new Date(res.body.timestamp).getTime()).not.toBeNaN();
+  });
+});
+
+describe('GET /specialties', () => {
+  it('returns 200 with a specialties array', async () => {
+    const res = await api.get<{ specialties: unknown[] }>('/specialties');
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as any).specialties)).toBe(true);
+  });
+});
+
+// ─── Auth Flow ────────────────────────────────────────────────────────────────
+
+describe('Auth flow (magic prefix)', () => {
+  it('request-code returns devCode for magic prefix phone', async () => {
+    const res = await api.post<{ message: string; devCode?: string }>(
+      '/auth/request-code',
+      { phone: TEST_PHONE }
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.message).toBe('Verification code sent');
+    expect(res.body.devCode).toBeDefined();
+    expect(res.body.devCode).toHaveLength(6);
+  });
+
+  it('verify-code creates new user and returns tokens', async () => {
+    // Re-request to get fresh code (previous test consumed its own)
+    auth = await authenticateTestPhone(TEST_PHONE);
+
+    expect(auth.accessToken).toBeDefined();
+    expect(auth.refreshToken).toBeDefined();
+    expect(auth.user).toBeDefined();
+    expect((auth.user as any).phone).toBe(TEST_PHONE);
+    expect(auth.isNewUser).toBe(true);
+  });
+
+  it('verify-code with wrong code returns 400', async () => {
+    // Request a code (won't use it)
+    await api.post('/auth/request-code', { phone: TEST_PHONE });
+
+    const res = await api.post<{ message: string }>('/auth/verify-code', {
+      phone: TEST_PHONE,
+      code: '000000',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.message).toMatch(/invalid/i);
+  });
+
+  it('re-authenticate returns existing user (isNewUser = false)', async () => {
+    // Re-authenticate the same test phone
+    const tokens = await authenticateTestPhone(TEST_PHONE);
+    expect(tokens.isNewUser).toBe(false);
+    expect((tokens.user as any).phone).toBe(TEST_PHONE);
+    // Update shared auth tokens
+    auth = tokens;
+  });
+});
+
+// ─── GET /auth/me ─────────────────────────────────────────────────────────────
+
+describe('GET /auth/me', () => {
+  it('returns current user with valid token', async () => {
+    const res = await api.get<{ id: string; phone: string }>('/auth/me', auth.accessToken);
+    expect(res.status).toBe(200);
+    expect(res.body.phone).toBe(TEST_PHONE);
+    expect(res.body.id).toBeDefined();
+  });
+
+  it('returns 401 without token', async () => {
+    const res = await api.get('/auth/me');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with garbage token', async () => {
+    const res = await api.get('/auth/me', 'not.a.real.token');
+    expect(res.status).toBe(401);
+  });
+});
+
+// ─── Token Refresh ────────────────────────────────────────────────────────────
+
+describe('POST /auth/refresh', () => {
+  it('issues new tokens with valid refresh token', async () => {
+    const res = await api.post<AuthTokens>('/auth/refresh', {
+      refreshToken: auth.refreshToken,
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.accessToken).toBeDefined();
+    expect(res.body.refreshToken).toBeDefined();
+    // Update for subsequent tests
+    auth = res.body;
+  });
+
+  it('returns 401 with explicit error for invalid refresh token', async () => {
+    const res = await api.post<{ error: string }>('/auth/refresh', {
+      refreshToken: 'invalid.refresh.token',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/invalid|expired/i);
+  });
+
+  it('rejects access token used as refresh token', async () => {
+    const res = await api.post<{ error: string }>('/auth/refresh', {
+      refreshToken: auth.accessToken,
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/invalid|expired/i);
+  });
+});
+
+// ─── Auth-gated Social Endpoints ─────────────────────────────────────────────
+
+describe('GET /events', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await api.get('/events');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with valid auth token', async () => {
+    const res = await api.get<{ events: unknown[] }>('/events', auth.accessToken);
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as any).events)).toBe(true);
+  });
+});
+
+describe('GET /posts', () => {
+  it('returns 200 without auth', async () => {
+    const res = await api.get<unknown>('/posts');
+    expect(res.status).toBe(200);
+  });
+
+  it('returns 200 with auth', async () => {
+    const res = await api.get<unknown>('/posts', auth.accessToken);
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('GET /sponsors', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await api.get('/sponsors');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with valid auth token', async () => {
+    const res = await api.get<{ sponsors: unknown[] }>('/sponsors', auth.accessToken);
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as any).sponsors)).toBe(true);
+  });
+});
+
+describe('GET /discounts', () => {
+  it('returns 401 without auth token', async () => {
+    const res = await api.get('/discounts');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with valid auth token', async () => {
+    const res = await api.get<{ discounts: unknown[] }>('/discounts', auth.accessToken);
+    expect(res.status).toBe(200);
+    expect(Array.isArray((res.body as any).discounts)).toBe(true);
+  });
+});
+
+// ─── Admin Endpoint Auth Guard ────────────────────────────────────────────────
+
+describe('Admin route token family guard', () => {
+  it('rejects social token on admin dashboard', async () => {
+    const res = await api.get('/admin/dashboard', auth.accessToken);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects social refresh token on admin refresh', async () => {
+    const res = await api.post<{ error: string }>('/admin/auth/refresh', {
+      refreshToken: auth.refreshToken,
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toMatch(/invalid|expired/i);
+  });
+});
+
+// ─── POST /auth/logout ────────────────────────────────────────────────────────
+
+describe('POST /auth/logout', () => {
+  it('returns 200 with valid token', async () => {
+    const res = await api.post('/auth/logout', {}, auth.accessToken);
+    expect(res.status).toBe(200);
+  });
+});
+
+// ─── Cleanup — run last ───────────────────────────────────────────────────────
+
+describe('Cleanup: delete test user', () => {
+  it('deletes the test user account via DELETE /auth/me', async () => {
+    // Re-authenticate (we just logged out)
+    auth = await authenticateTestPhone(TEST_PHONE);
+
+    const res = await api.delete('/auth/me', auth.accessToken);
+    expect(res.status).toBe(200);
+  });
+
+  it('confirms test user no longer exists', async () => {
+    // Auth should fail after deletion
+    const res = await api.get('/auth/me', auth.accessToken);
+    // Either 401 (token invalid after delete) or 404
+    expect([401, 404]).toContain(res.status);
+  });
+});

--- a/packages/api/tests/e2e/e2e.test.ts
+++ b/packages/api/tests/e2e/e2e.test.ts
@@ -241,9 +241,13 @@ describe('Cleanup: delete test user', () => {
   });
 
   it('confirms test user no longer exists', async () => {
-    // Auth should fail after deletion
-    const res = await api.get('/auth/me', auth.accessToken);
-    // Either 401 (token invalid after delete) or 404
-    expect([401, 404]).toContain(res.status);
+    // Re-authenticate from scratch. If the user was truly deleted,
+    // the API will auto-create a new account and return isNewUser=true.
+    const reAuth = await authenticateTestPhone(TEST_PHONE);
+    expect(reAuth.isNewUser).toBe(true);
+
+    // Clean up the re-created test account so the environment stays pristine.
+    const del = await api.delete('/auth/me', reAuth.accessToken);
+    expect(del.status).toBe(200);
   });
 });

--- a/packages/api/tests/e2e/e2e.test.ts
+++ b/packages/api/tests/e2e/e2e.test.ts
@@ -102,10 +102,10 @@ describe('Auth flow (magic prefix)', () => {
 
 describe('GET /auth/me', () => {
   it('returns current user with valid token', async () => {
-    const res = await api.get<{ id: string; phone: string }>('/auth/me', auth.accessToken);
+    const res = await api.get<{ user: { id: string; phone: string } }>('/auth/me', auth.accessToken);
     expect(res.status).toBe(200);
-    expect(res.body.phone).toBe(TEST_PHONE);
-    expect(res.body.id).toBeDefined();
+    expect((res.body as any).user.phone).toBe(TEST_PHONE);
+    expect((res.body as any).user.id).toBeDefined();
   });
 
   it('returns 401 without token', async () => {

--- a/packages/database/migrations/005_fix_audit_log_user_delete_cascade.sql
+++ b/packages/database/migrations/005_fix_audit_log_user_delete_cascade.sql
@@ -1,0 +1,38 @@
+-- 005_fix_audit_log_user_delete_cascade.sql
+--
+-- Bug: DELETE FROM users fails with "audit_log is immutable" when the user
+-- has any audit_log entries. Root cause: migration 002 installed an immutability
+-- trigger (prevent_audit_log_mutation) that raises on ANY UPDATE, including
+-- the ON DELETE SET NULL FK cascade that PostgreSQL performs on audit_log.actor_id
+-- when a referenced user is deleted. Additionally, the ck_audit_log_actor_identity
+-- CHECK constraint requires (actor_type='user' AND actor_id IS NOT NULL), so a
+-- plain SET NULL would also violate the check.
+--
+-- Fix: Replace prevent_audit_log_mutation() with a version that permits the
+-- one legitimate "soft mutation" — tombstoning the actor reference when a user
+-- is deleted (actor_id non-null → NULL, all other columns untouched). The
+-- function simultaneously promotes actor_type to 'system' to satisfy the CHECK
+-- constraint. All other mutations continue to raise an exception.
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Permit FK cascade from ON DELETE SET NULL on audit_log.actor_id.
+  -- Pattern: only actor_id changes (from non-null to NULL); every other
+  -- business column is untouched. We promote actor_type to 'system' so
+  -- the ck_audit_log_actor_identity CHECK constraint remains satisfied.
+  IF TG_OP = 'UPDATE'
+     AND OLD.actor_id IS NOT NULL
+     AND NEW.actor_id IS NULL
+     AND NEW.action            IS NOT DISTINCT FROM OLD.action
+     AND NEW.entity_type       IS NOT DISTINCT FROM OLD.entity_type
+     AND NEW.entity_id         IS NOT DISTINCT FROM OLD.entity_id
+     AND NEW.admin_actor_id    IS NOT DISTINCT FROM OLD.admin_actor_id
+  THEN
+    NEW.actor_type := 'system';
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is immutable';
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/database/migrations/006_fix_audit_log_admin_delete_cascade.sql
+++ b/packages/database/migrations/006_fix_audit_log_admin_delete_cascade.sql
@@ -1,0 +1,52 @@
+-- 006_fix_audit_log_admin_delete_cascade.sql
+--
+-- Bug: DELETE FROM admin_users fails with "audit_log is immutable" when the
+-- admin has any audit_log entries where admin_actor_id references them.
+-- Root cause: migration 005 extended prevent_audit_log_mutation() to permit
+-- the actor_id FK cascade (users → audit_log.actor_id SET NULL) but did NOT
+-- cover the parallel admin_actor_id FK cascade (admin_users → audit_log.admin_actor_id
+-- SET NULL). Both columns have the same ON DELETE SET NULL behaviour; both
+-- trigger the immutability check.
+--
+-- Fix: Extend prevent_audit_log_mutation() with a second permitted path — the
+-- admin_actor_id non-null → NULL cascade. Unlike the user case, no actor_type
+-- promotion is required because the ck_audit_log_actor_identity CHECK
+-- constraint only governs actor_type/actor_id, not admin_actor_id.
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+  -- Permit FK cascade from ON DELETE SET NULL on audit_log.actor_id.
+  -- Pattern: only actor_id changes (from non-null to NULL); every other
+  -- business column is untouched. We promote actor_type to 'system' so
+  -- the ck_audit_log_actor_identity CHECK constraint remains satisfied.
+  IF TG_OP = 'UPDATE'
+     AND OLD.actor_id IS NOT NULL
+     AND NEW.actor_id IS NULL
+     AND NEW.action            IS NOT DISTINCT FROM OLD.action
+     AND NEW.entity_type       IS NOT DISTINCT FROM OLD.entity_type
+     AND NEW.entity_id         IS NOT DISTINCT FROM OLD.entity_id
+     AND NEW.admin_actor_id    IS NOT DISTINCT FROM OLD.admin_actor_id
+  THEN
+    NEW.actor_type := 'system';
+    RETURN NEW;
+  END IF;
+
+  -- Permit FK cascade from ON DELETE SET NULL on audit_log.admin_actor_id.
+  -- Pattern: only admin_actor_id changes (from non-null to NULL); every
+  -- other business column is untouched. actor_type is not affected because
+  -- the CHECK constraint does not govern admin_actor_id.
+  IF TG_OP = 'UPDATE'
+     AND OLD.admin_actor_id IS NOT NULL
+     AND NEW.admin_actor_id IS NULL
+     AND NEW.action         IS NOT DISTINCT FROM OLD.action
+     AND NEW.entity_type    IS NOT DISTINCT FROM OLD.entity_type
+     AND NEW.entity_id      IS NOT DISTINCT FROM OLD.entity_id
+     AND NEW.actor_id       IS NOT DISTINCT FROM OLD.actor_id
+  THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is immutable';
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/database/migrations/007_fix_audit_log_immutability_full_row.sql
+++ b/packages/database/migrations/007_fix_audit_log_immutability_full_row.sql
@@ -74,7 +74,7 @@ BEGIN
     END IF;
 
     -- Apply the intended tombstoned actor identity.
-    NEW.admin_actor_id := NULL;
+    NEW.admin_actor_id := v_actor_id;
     NEW.actor_type     := v_actor_type;
     RETURN NEW;
   END IF;

--- a/packages/database/migrations/007_fix_audit_log_immutability_full_row.sql
+++ b/packages/database/migrations/007_fix_audit_log_immutability_full_row.sql
@@ -1,0 +1,84 @@
+-- 007_fix_audit_log_immutability_full_row.sql
+--
+-- Two bugs addressed in this migration:
+--
+-- Bug 1: DELETE FROM admin_users still fails with "audit_log is immutable"
+-- after migration 006. Root cause: migration 006 added the admin_actor_id
+-- cascade path but forgot actor_type promotion. When admin_actor_id is
+-- cascaded to NULL, the row has actor_type='admin'. After the cascade:
+-- actor_type='admin', actor_id=NULL, admin_actor_id=NULL — which satisfies
+-- none of the three ck_audit_log_actor_identity branches:
+--   (user AND actor_id NOT NULL AND admin_actor_id IS NULL)    → no
+--   (admin AND actor_id IS NULL AND admin_actor_id NOT NULL)   → no (admin_actor_id is now NULL)
+--   (system AND actor_id IS NULL AND admin_actor_id IS NULL)   → no (actor_type is still 'admin')
+-- Fix: promote actor_type to 'system' in the admin_actor_id branch too.
+--
+-- Bug 2: Both permitted UPDATE branches in migrations 005 and 006 only compared
+-- a subset of audit_log columns (action/entity_type/entity_id/correlated FK).
+-- Other columns (old_values/new_values/metadata/result/request_id/etc) could
+-- be mutated in the same UPDATE alongside a FK-null and bypass the trigger.
+-- Fix: Use a full NEW IS DISTINCT FROM OLD comparison, temporarily restoring
+-- the changing columns to their OLD values to isolate the check, then
+-- re-applying the intended new values before returning.
+
+CREATE OR REPLACE FUNCTION prevent_audit_log_mutation()
+RETURNS TRIGGER AS $$
+DECLARE
+  v_actor_id   audit_log.actor_id%TYPE;
+  v_actor_type audit_log.actor_type%TYPE;
+BEGIN
+  -- Permit FK cascade: ON DELETE SET NULL on audit_log.actor_id (user deleted).
+  -- The row must change ONLY actor_id (NULL) and actor_type ('system').
+  -- Every other column must be identical to confirm this is a pure FK cascade.
+  IF TG_OP = 'UPDATE'
+     AND OLD.actor_id IS NOT NULL
+     AND NEW.actor_id IS NULL
+  THEN
+    -- Save intended final values.
+    v_actor_id   := NEW.actor_id;   -- will be NULL
+    v_actor_type := 'system';
+
+    -- Temporarily restore actor identity to OLD values for full-row comparison.
+    NEW.actor_id   := OLD.actor_id;
+    NEW.actor_type := OLD.actor_type;
+
+    -- If any other column changed, this is not a pure FK cascade — reject it.
+    IF NEW IS DISTINCT FROM OLD THEN
+      RAISE EXCEPTION 'audit_log is immutable';
+    END IF;
+
+    -- Apply the intended tombstoned actor identity.
+    NEW.actor_id   := v_actor_id;
+    NEW.actor_type := v_actor_type;
+    RETURN NEW;
+  END IF;
+
+  -- Permit FK cascade: ON DELETE SET NULL on audit_log.admin_actor_id (admin deleted).
+  -- The row must change ONLY admin_actor_id (NULL) and actor_type ('system').
+  -- Every other column must be identical to confirm this is a pure FK cascade.
+  IF TG_OP = 'UPDATE'
+     AND OLD.admin_actor_id IS NOT NULL
+     AND NEW.admin_actor_id IS NULL
+  THEN
+    -- Save intended final values.
+    v_actor_id   := NEW.admin_actor_id; -- will be NULL (reuse var for clarity)
+    v_actor_type := 'system';
+
+    -- Temporarily restore admin_actor_id and actor_type to OLD values for full-row comparison.
+    NEW.admin_actor_id := OLD.admin_actor_id;
+    NEW.actor_type     := OLD.actor_type;
+
+    -- If any other column changed, this is not a pure FK cascade — reject it.
+    IF NEW IS DISTINCT FROM OLD THEN
+      RAISE EXCEPTION 'audit_log is immutable';
+    END IF;
+
+    -- Apply the intended tombstoned actor identity.
+    NEW.admin_actor_id := NULL;
+    NEW.actor_type     := v_actor_type;
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'audit_log is immutable';
+END;
+$$ LANGUAGE plpgsql;

--- a/packages/social-app/pubspec.yaml
+++ b/packages/social-app/pubspec.yaml
@@ -39,6 +39,8 @@ dev_dependencies:
     sdk: flutter
   flutter_lints: ^3.0.1
   build_runner: ^2.4.7
+  mocktail: ^1.0.4
+  network_image_mock: ^2.1.1
 
 flutter:
   uses-material-design: true

--- a/packages/social-app/test/helpers/fake_app_state.dart
+++ b/packages/social-app/test/helpers/fake_app_state.dart
@@ -46,6 +46,10 @@ class FakeAppState extends AppState {
   @override
   String? get error => deleteError;
 
+  // No-op: prevents MissingPluginException from SecureStorage in widget tests.
+  @override
+  Future<void> initialize() async {}
+
   @override
   Future<bool> deleteAccount() async {
     deleteCalls++;

--- a/packages/social-app/test/helpers/fake_app_state.dart
+++ b/packages/social-app/test/helpers/fake_app_state.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+import 'package:industrynight_shared/shared.dart';
+import 'package:industrynight_social/providers/app_state.dart';
+import 'package:provider/provider.dart';
+
+/// Shared FakeAppState for widget tests.
+///
+/// Override only what each test needs — everything else returns sensible defaults.
+class FakeAppState extends AppState {
+  FakeAppState({
+    this.fakeUser,
+    this.fakeEvents = const [],
+    this.deleteResult = true,
+    this.deleteError,
+    this.isLoadingOverride = false,
+    this.requestCodeResult,
+    this.verifyCodeResult,
+  }) : super(
+          apiClient: ApiClient(baseUrl: 'http://localhost:3000'),
+          storage: SecureStorage(),
+        );
+
+  final User? fakeUser;
+  final List<Event> fakeEvents;
+  final bool deleteResult;
+  final String? deleteError;
+  final bool isLoadingOverride;
+  final String? requestCodeResult; // devCode returned
+  final bool? verifyCodeResult;
+
+  int deleteCalls = 0;
+  int requestCodeCalls = 0;
+  int verifyCodeCalls = 0;
+  String? lastRequestedPhone;
+  String? lastVerifiedCode;
+
+  @override
+  User? get currentUser => fakeUser;
+
+  @override
+  bool get isLoggedIn => fakeUser != null;
+
+  @override
+  bool get isLoading => isLoadingOverride;
+
+  @override
+  String? get error => deleteError;
+
+  @override
+  Future<bool> deleteAccount() async {
+    deleteCalls++;
+    return deleteResult;
+  }
+
+  @override
+  Future<String?> requestVerificationCode(String phone) async {
+    requestCodeCalls++;
+    lastRequestedPhone = phone;
+    return requestCodeResult;
+  }
+
+  @override
+  Future<bool> verifyCode(String phone, String code) async {
+    verifyCodeCalls++;
+    lastVerifiedCode = code;
+    return verifyCodeResult ?? true;
+  }
+}
+
+/// Test user with sensible defaults.
+User testUser({
+  String id = 'user-test-1',
+  String phone = '+15555550001',
+  String name = 'Test User',
+  String? bio,
+  String? profilePhotoUrl,
+}) {
+  final now = DateTime.now();
+  return User(
+    id: id,
+    phone: phone,
+    name: name,
+    bio: bio,
+    profilePhotoUrl: profilePhotoUrl,
+    createdAt: now,
+  );
+}
+
+/// Wrap a widget with Provider and MaterialApp for testing.
+Widget buildTestWidget(
+  Widget child,
+  FakeAppState appState, {
+  ThemeData? theme,
+}) {
+  return ChangeNotifierProvider<AppState>.value(
+    value: appState,
+    child: MaterialApp(
+      theme: theme ?? ThemeData.dark(),
+      home: child,
+    ),
+  );
+}

--- a/packages/social-app/test/helpers/fake_app_state.dart
+++ b/packages/social-app/test/helpers/fake_app_state.dart
@@ -9,7 +9,6 @@ import 'package:provider/provider.dart';
 class FakeAppState extends AppState {
   FakeAppState({
     this.fakeUser,
-    this.fakeEvents = const [],
     this.deleteResult = true,
     this.deleteError,
     this.isLoadingOverride = false,
@@ -21,7 +20,6 @@ class FakeAppState extends AppState {
         );
 
   final User? fakeUser;
-  final List<Event> fakeEvents;
   final bool deleteResult;
   final String? deleteError;
   final bool isLoadingOverride;

--- a/packages/social-app/test/unit/validators_test.dart
+++ b/packages/social-app/test/unit/validators_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:industrynight_shared/shared.dart';
+
+void main() {
+  group('Phone number validation', () {
+    test('accepts valid US E.164 phone number', () {
+      expect(isValidPhoneNumber('+15555550001'), isTrue);
+      expect(isValidPhoneNumber('+12125551234'), isTrue);
+    });
+
+    test('accepts 10-digit local format (no country code)', () {
+      expect(isValidPhoneNumber('5555550001'), isTrue);
+    });
+
+    test('accepts 11-digit format with leading 1', () {
+      expect(isValidPhoneNumber('15555550001'), isTrue);
+    });
+
+    test('accepts formatted numbers with dashes (strips punctuation)', () {
+      expect(isValidPhoneNumber('+1555-555-0001'), isTrue);
+    });
+
+    test('rejects too-short numbers', () {
+      expect(isValidPhoneNumber('+1555'), isFalse);
+      expect(isValidPhoneNumber('555'), isFalse);
+    });
+
+    test('rejects empty string', () {
+      expect(isValidPhoneNumber(''), isFalse);
+    });
+  });
+
+  group('Phone number normalization', () {
+    test('normalizes 10-digit number to E.164', () {
+      final result = normalizePhoneNumber('5555550001');
+      expect(result, equals('+15555550001'));
+    });
+
+    test('normalizes 11-digit number with leading 1 to E.164', () {
+      final result = normalizePhoneNumber('15555550001');
+      expect(result, equals('+15555550001'));
+    });
+
+    test('passes through already-normalized E.164 number', () {
+      final result = normalizePhoneNumber('+15555550001');
+      expect(result, equals('+15555550001'));
+    });
+  });
+}

--- a/packages/social-app/test/widgets/auth/phone_entry_screen_test.dart
+++ b/packages/social-app/test/widgets/auth/phone_entry_screen_test.dart
@@ -46,7 +46,7 @@ void main() {
       expect(find.text('Continue'), findsOneWidget);
     });
 
-    testWidgets('shows error snackbar for invalid phone number', (tester) async {
+    testWidgets('does not submit with invalid phone number', (tester) async {
       usePortraitViewport(tester);
       await tester.pumpWidget(buildScreen());
       await tester.pumpAndSettle();
@@ -56,7 +56,7 @@ void main() {
       await tester.tap(find.text('Continue'));
       await tester.pumpAndSettle();
 
-      // Should not call requestCode with invalid input
+      // Validation blocks submission — requestCode must not be called
       expect(appState.requestCodeCalls, 0);
     });
 

--- a/packages/social-app/test/widgets/auth/phone_entry_screen_test.dart
+++ b/packages/social-app/test/widgets/auth/phone_entry_screen_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:industrynight_social/features/auth/screens/phone_entry_screen.dart';
+import 'package:provider/provider.dart';
+import 'package:industrynight_social/providers/app_state.dart';
+import 'package:industrynight_shared/shared.dart';
+
+import '../../helpers/fake_app_state.dart';
+
+void main() {
+  group('PhoneEntryScreen', () {
+    late FakeAppState appState;
+
+    setUp(() {
+      appState = FakeAppState();
+    });
+
+    Widget buildScreen() => buildTestWidget(PhoneEntryScreen(), appState);
+
+    /// Set a portrait phone viewport so auth screen layout doesn't overflow.
+    void usePortraitViewport(WidgetTester tester) {
+      tester.view.physicalSize = const Size(390, 844); // iPhone 14 logical size
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+    }
+
+    testWidgets('renders phone input and Continue button', (tester) async {
+      usePortraitViewport(tester);
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(TextFormField), findsOneWidget);
+      expect(find.text('Continue'), findsOneWidget);
+    });
+
+    testWidgets('Continue button is present and tappable', (tester) async {
+      usePortraitViewport(tester);
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      // Enter a valid phone number
+      await tester.enterText(find.byType(TextFormField), '5555550001');
+      await tester.pumpAndSettle();
+
+      expect(find.text('Continue'), findsOneWidget);
+    });
+
+    testWidgets('shows error snackbar for invalid phone number', (tester) async {
+      usePortraitViewport(tester);
+      await tester.pumpWidget(buildScreen());
+      await tester.pumpAndSettle();
+
+      // Enter invalid phone (too short)
+      await tester.enterText(find.byType(TextFormField), '123');
+      await tester.tap(find.text('Continue'));
+      await tester.pumpAndSettle();
+
+      // Should not call requestCode with invalid input
+      expect(appState.requestCodeCalls, 0);
+    });
+
+    testWidgets('valid phone triggers loading state (submit initiated)',
+        (tester) async {
+      usePortraitViewport(tester);
+      appState = FakeAppState(requestCodeResult: '123456');
+      await tester.pumpWidget(buildTestWidget(PhoneEntryScreen(), appState));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextFormField), '5555550099');
+      await tester.tap(find.text('Continue'));
+      await tester.pump(); // one frame — catches isSubmitting = true before async
+
+      // Button enters loading state, confirming form validated and submit started
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Continue'), findsNothing);
+    });
+
+    testWidgets('shows loading indicator while submitting', (tester) async {
+      usePortraitViewport(tester);
+      // Use a state that simulates loading
+      appState = FakeAppState(isLoadingOverride: true);
+      await tester.pumpWidget(buildTestWidget(PhoneEntryScreen(), appState));
+      await tester.pump();
+
+      // During loading, button should show progress or be disabled
+      // (exact widget depends on implementation)
+      expect(find.byType(PhoneEntryScreen), findsOneWidget);
+    });
+  });
+}

--- a/packages/social-app/test/widgets/community/community_feed_screen_test.dart
+++ b/packages/social-app/test/widgets/community/community_feed_screen_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:industrynight_social/features/community/screens/community_feed_screen.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+import '../../helpers/fake_app_state.dart';
+
+void main() {
+  group('CommunityFeedScreen', () {
+    testWidgets('renders without crashing', (tester) async {
+      final appState = FakeAppState(fakeUser: testUser());
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(CommunityFeedScreen(), appState));
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.byType(CommunityFeedScreen), findsOneWidget);
+    });
+
+    testWidgets('shows FloatingActionButton for creating posts', (tester) async {
+      final appState = FakeAppState(fakeUser: testUser());
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(CommunityFeedScreen(), appState));
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.byType(FloatingActionButton), findsOneWidget);
+    });
+
+    testWidgets('unlike does not crash (regression test)', (tester) async {
+      // This test guards against the unlike crash bug.
+      // Tapping like/unlike on post cards should not throw.
+      final appState = FakeAppState(fakeUser: testUser());
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(CommunityFeedScreen(), appState));
+        await tester.pumpAndSettle();
+
+        // If there are any like buttons visible, tap them — should not crash
+        final likeButtons = find.byIcon(Icons.favorite);
+        final likeOutlineButtons = find.byIcon(Icons.favorite_border);
+        if (likeButtons.evaluate().isNotEmpty) {
+          await tester.tap(likeButtons.first);
+          await tester.pumpAndSettle();
+        }
+        if (likeOutlineButtons.evaluate().isNotEmpty) {
+          await tester.tap(likeOutlineButtons.first);
+          await tester.pumpAndSettle();
+        }
+      });
+
+      // No exception thrown = pass
+      expect(find.byType(CommunityFeedScreen), findsOneWidget);
+    });
+
+    testWidgets('shows AppBar with title', (tester) async {
+      final appState = FakeAppState(fakeUser: testUser());
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(CommunityFeedScreen(), appState));
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.byType(AppBar), findsOneWidget);
+    });
+  });
+}

--- a/packages/social-app/test/widgets/events/events_list_screen_test.dart
+++ b/packages/social-app/test/widgets/events/events_list_screen_test.dart
@@ -17,21 +17,20 @@ void main() {
       });
     });
 
-    testWidgets('shows no upcoming events message when list is empty',
+    testWidgets('renders without crashing after API resolves (smoke test)',
         (tester) async {
-      final appState = FakeAppState(fakeEvents: []);
+      final appState = FakeAppState();
       await mockNetworkImagesFor(() async {
         await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));
         await tester.pumpAndSettle();
       });
 
-      // Either an empty state message or empty list — the screen renders
       expect(find.byType(EventsListScreen), findsOneWidget);
     });
 
-    testWidgets('shows Retry button on error state', (tester) async {
-      // Events screen manages its own loading state locally,
-      // so we just verify the screen renders without crashing
+    testWidgets('renders on first pump before API resolves (smoke test)',
+        (tester) async {
+      // Events screen manages its own loading state locally.
       final appState = FakeAppState();
       await mockNetworkImagesFor(() async {
         await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));

--- a/packages/social-app/test/widgets/events/events_list_screen_test.dart
+++ b/packages/social-app/test/widgets/events/events_list_screen_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:industrynight_social/features/events/screens/events_list_screen.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+
+import '../../helpers/fake_app_state.dart';
+
+void main() {
+  group('EventsListScreen', () {
+    testWidgets('shows loading indicator on first frame before API completes',
+        (tester) async {
+      final appState = FakeAppState();
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));
+        // Check immediately — first frame has _isLoading = true before async resolves
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+
+    testWidgets('shows no upcoming events message when list is empty',
+        (tester) async {
+      final appState = FakeAppState(fakeEvents: []);
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));
+        await tester.pumpAndSettle();
+      });
+
+      // Either an empty state message or empty list — the screen renders
+      expect(find.byType(EventsListScreen), findsOneWidget);
+    });
+
+    testWidgets('shows Retry button on error state', (tester) async {
+      // Events screen manages its own loading state locally,
+      // so we just verify the screen renders without crashing
+      final appState = FakeAppState();
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));
+        await tester.pump();
+      });
+
+      expect(find.byType(EventsListScreen), findsOneWidget);
+    });
+
+    testWidgets('renders without crashing (including error state)',
+        (tester) async {
+      // In test environment, API calls return 400 immediately, so the screen
+      // transitions to error state. Verify it renders gracefully.
+      final appState = FakeAppState();
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(buildTestWidget(EventsListScreen(), appState));
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.byType(EventsListScreen), findsOneWidget);
+    });
+  });
+}

--- a/packages/social-app/test/widgets/networking/connect_tab_screen_test.dart
+++ b/packages/social-app/test/widgets/networking/connect_tab_screen_test.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:industrynight_shared/shared.dart';
+import 'package:industrynight_social/features/networking/screens/connect_tab_screen.dart';
+import 'package:industrynight_social/features/networking/networking_state.dart';
+import 'package:industrynight_social/providers/app_state.dart';
+import 'package:network_image_mock/network_image_mock.dart';
+import 'package:provider/provider.dart';
+
+import '../../helpers/fake_app_state.dart';
+
+/// Wraps [ConnectTabScreen] with both required providers.
+///
+/// [ConnectTabScreen] reads [AppState] and [NetworkingState]. Providing a
+/// [NetworkingState] backed by a non-responsive URL lets API calls fail
+/// gracefully (caught internally) while keeping widget tests hermetic.
+Widget _buildConnectWidget({User? user}) {
+  final appState = FakeAppState(fakeUser: user ?? testUser());
+  final networkingState = NetworkingState(
+    connectionsApi: ConnectionsApi(
+      ApiClient(baseUrl: 'http://localhost:3000'),
+    ),
+    getCurrentUserId: () => appState.currentUser?.id ?? '',
+  );
+
+  return MultiProvider(
+    providers: [
+      ChangeNotifierProvider<AppState>.value(value: appState),
+      ChangeNotifierProvider<NetworkingState>.value(value: networkingState),
+    ],
+    child: MaterialApp(
+      theme: ThemeData.dark(),
+      home: const ConnectTabScreen(),
+    ),
+  );
+}
+
+void main() {
+  group('ConnectTabScreen — inactive state (no active event)', () {
+    testWidgets('renders without crashing', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(_buildConnectWidget());
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.byType(ConnectTabScreen), findsOneWidget);
+    });
+
+    testWidgets('shows AppBar with Connect title', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(_buildConnectWidget());
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.text('Connect'), findsOneWidget);
+    });
+
+    testWidgets('shows QR icon in inactive state', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(_buildConnectWidget());
+        await tester.pumpAndSettle();
+      });
+
+      // Inactive state always shows a large QR code icon as placeholder
+      expect(find.byIcon(Icons.qr_code), findsOneWidget);
+    });
+
+    testWidgets('shows Browse Events button when no tickets', (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(_buildConnectWidget());
+        await tester.pumpAndSettle();
+      });
+
+      expect(find.text('Browse Events'), findsOneWidget);
+    });
+
+    testWidgets('shows CircularProgressIndicator on first frame before API resolves',
+        (tester) async {
+      await mockNetworkImagesFor(() async {
+        await tester.pumpWidget(_buildConnectWidget());
+        // Check immediately after first frame — _isLoadingTickets starts true
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+        // After settling, loading resolves and inactive state is shown
+        await tester.pumpAndSettle();
+        expect(find.byType(ConnectTabScreen), findsOneWidget);
+      });
+    });
+  });
+}

--- a/scripts/closeout-test.sh
+++ b/scripts/closeout-test.sh
@@ -38,6 +38,11 @@ LOCAL_ONLY=false
 LOG_FILE=""
 LOCAL_API_PID=""
 
+# Ephemeral smoke admin — created before phase 7, deleted after (success or failure)
+SMOKE_ADMIN_EMAIL="smoke-test@industrynight.internal"
+SMOKE_ADMIN_PASSWORD=""  # generated per-run
+SMOKE_ADMIN_CREATED=false
+
 # --------------------------------------------------------------------------
 # Usage
 # --------------------------------------------------------------------------
@@ -163,6 +168,7 @@ exec > >(tee -a "$LOG_FILE") 2>&1
 # Trap: print summary on Ctrl-C
 # --------------------------------------------------------------------------
 cleanup() {
+  teardown_smoke_admin  # no-op if never created; safe to call multiple times
   if [[ -n "$LOCAL_API_PID" ]]; then
     kill "$LOCAL_API_PID" 2>/dev/null || true
     LOCAL_API_PID=""
@@ -486,6 +492,51 @@ sanity_gate() {
   log_info "AWS phases confirmed — proceeding."
 }
 
+# Create an ephemeral smoke-test admin account before phase 7.
+# Uses a random password generated fresh each run — never stored anywhere.
+setup_smoke_admin() {
+  fetch_db_password || return 0  # soft failure: skip admin smoke if no DB creds
+
+  # Generate a random 24-char alphanumeric password (no special chars to avoid
+  # shell quoting landmines in the env var forwarding to api-smoke.sh).
+  SMOKE_ADMIN_PASSWORD="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom 2>/dev/null | head -c 24 || true)"
+  if [[ -z "$SMOKE_ADMIN_PASSWORD" ]]; then
+    log_warn "Could not generate random password — admin smoke check will be skipped."
+    return 0
+  fi
+
+  log_info "Creating ephemeral smoke admin ($SMOKE_ADMIN_EMAIL)..."
+  if DB_PASSWORD="$DB_PASSWORD" \
+     node "$PROJECT_ROOT/scripts/seed-smoke-admin.js" \
+       --create \
+       --email "$SMOKE_ADMIN_EMAIL" \
+       --password "$SMOKE_ADMIN_PASSWORD"; then
+    SMOKE_ADMIN_CREATED=true
+    log_success "Smoke admin created."
+  else
+    log_warn "Smoke admin creation failed — admin smoke check will be skipped."
+  fi
+}
+
+# Delete the ephemeral smoke-test admin account. Idempotent: safe to call
+# multiple times (SMOKE_ADMIN_CREATED guards against duplicate calls).
+teardown_smoke_admin() {
+  if [[ "$SMOKE_ADMIN_CREATED" != true ]]; then
+    return 0
+  fi
+  log_info "Removing ephemeral smoke admin ($SMOKE_ADMIN_EMAIL)..."
+  if DB_PASSWORD="${DB_PASSWORD:-}" \
+     node "$PROJECT_ROOT/scripts/seed-smoke-admin.js" \
+       --delete \
+       --email "$SMOKE_ADMIN_EMAIL" 2>/dev/null; then
+    log_success "Smoke admin removed."
+  else
+    log_warn "Smoke admin cleanup failed — manually run:"
+    log_warn "  psql ... -c \"DELETE FROM admin_users WHERE email = '$SMOKE_ADMIN_EMAIL';\""
+  fi
+  SMOKE_ADMIN_CREATED=false
+}
+
 # Fetch DB_PASSWORD from Secrets Manager if not already in environment.
 fetch_db_password() {
   if [[ -n "${DB_PASSWORD:-}" ]]; then
@@ -534,51 +585,26 @@ phase6_aws_e2e() {
   API_BASE_URL="$aws_url" npm run test:e2e
 }
 
-# Fetch admin smoke credentials from Secrets Manager if not already set.
-# Expects keys SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD in the same
-# secret used for DB creds (industrynight/database-{env}).
-fetch_smoke_admin_creds() {
-  if [[ -n "${SMOKE_ADMIN_EMAIL:-}" && -n "${SMOKE_ADMIN_PASSWORD:-}" ]]; then
-    log_info "Using SMOKE_ADMIN_EMAIL/PASSWORD from environment."
-    return 0
-  fi
-
-  log_info "SMOKE_ADMIN_EMAIL not set — checking Secrets Manager ($SECRETS_ID)..."
-
-  local secret_json
-  if ! secret_json=$(aws_cmd secretsmanager get-secret-value \
-    --secret-id "$SECRETS_ID" \
-    --query 'SecretString' \
-    --output text 2>&1); then
-    log_warn "Could not reach Secrets Manager — admin smoke check will be skipped."
-    return 0
-  fi
-
-  local email password
-  email=$(echo "$secret_json" | python3 -c \
-    "import json,sys; o=json.load(sys.stdin); print(o.get('SMOKE_ADMIN_EMAIL',''))" 2>/dev/null || true)
-  password=$(echo "$secret_json" | python3 -c \
-    "import json,sys; o=json.load(sys.stdin); print(o.get('SMOKE_ADMIN_PASSWORD',''))" 2>/dev/null || true)
-
-  if [[ -n "$email" && -n "$password" ]]; then
-    export SMOKE_ADMIN_EMAIL="$email"
-    export SMOKE_ADMIN_PASSWORD="$password"
-    log_success "Admin smoke creds loaded from Secrets Manager."
-  else
-    log_warn "SMOKE_ADMIN_EMAIL/PASSWORD not found in $SECRETS_ID — admin smoke check will be skipped."
-    log_warn "To enable: add keys SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD to the secret, or export them before running this script."
-  fi
-}
-
 phase7_smoke() {
-  # Forward SMOKE_TEST_PHONE from the loaded environment (dev.env defines it
-  # as a magic-prefix number; prod leaves it unset — set it manually for prod).
-  fetch_smoke_admin_creds
+  # Provision an ephemeral admin account solely for this smoke check.
+  # It is deleted in teardown_smoke_admin(), which also runs via the EXIT trap.
+  setup_smoke_admin
 
+  local admin_email="" admin_password=""
+  if [[ "$SMOKE_ADMIN_CREATED" == true ]]; then
+    admin_email="$SMOKE_ADMIN_EMAIL"
+    admin_password="$SMOKE_ADMIN_PASSWORD"
+  fi
+
+  local smoke_exit=0
   SMOKE_TEST_PHONE="${SMOKE_TEST_PHONE:-}" \
-  SMOKE_ADMIN_EMAIL="${SMOKE_ADMIN_EMAIL:-}" \
-  SMOKE_ADMIN_PASSWORD="${SMOKE_ADMIN_PASSWORD:-}" \
-    "$PROJECT_ROOT/scripts/api-smoke.sh" --env "$IN_ENV"
+  SMOKE_ADMIN_EMAIL="$admin_email" \
+  SMOKE_ADMIN_PASSWORD="$admin_password" \
+    "$PROJECT_ROOT/scripts/api-smoke.sh" --env "$IN_ENV" || smoke_exit=$?
+
+  teardown_smoke_admin
+
+  return $smoke_exit
 }
 
 # --------------------------------------------------------------------------

--- a/scripts/closeout-test.sh
+++ b/scripts/closeout-test.sh
@@ -287,6 +287,22 @@ phase3_local_e2e() {
     return 0
   fi
 
+  # ── Pre-flight: ensure port 3000 is free ─────────────────────────────────
+  local stale_pid
+  stale_pid=$(lsof -ti :3000 2>/dev/null || true)
+  if [[ -n "$stale_pid" ]]; then
+    log_warn "Port 3000 already in use (PID $stale_pid) — terminating stale process..."
+    echo "$stale_pid" | xargs kill 2>/dev/null || true
+    sleep 2
+    stale_pid=$(lsof -ti :3000 2>/dev/null || true)
+    if [[ -n "$stale_pid" ]]; then
+      log_error "Port 3000 still in use after termination attempt — phase 3 skipped."
+      RESULTS[3]="SKIP"
+      return 0
+    fi
+    log_info "Port 3000 cleared."
+  fi
+
   # ── Pick a free port for postgres ────────────────────────────────────────
   local pg_port
   pg_port=$(python3 -c "
@@ -300,8 +316,16 @@ import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.c
   # ── Cleanup helper (called on early return) ───────────────────────────────
   local_e2e_cleanup() {
     if [[ -n "$LOCAL_API_PID" ]]; then
+      # Kill direct children (ts-node-dev → node) before the subshell
+      pkill -P "$LOCAL_API_PID" 2>/dev/null || true
       kill "$LOCAL_API_PID" 2>/dev/null || true
       LOCAL_API_PID=""
+    fi
+    # Belt-and-suspenders: flush any process still holding port 3000
+    local _port_pids
+    _port_pids=$(lsof -ti :3000 2>/dev/null || true)
+    if [[ -n "$_port_pids" ]]; then
+      echo "$_port_pids" | xargs kill 2>/dev/null || true
     fi
     docker rm -f "$pg_container" >/dev/null 2>&1 || true
     rm -f "$api_log"

--- a/scripts/closeout-test.sh
+++ b/scripts/closeout-test.sh
@@ -534,8 +534,51 @@ phase6_aws_e2e() {
   API_BASE_URL="$aws_url" npm run test:e2e
 }
 
+# Fetch admin smoke credentials from Secrets Manager if not already set.
+# Expects keys SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD in the same
+# secret used for DB creds (industrynight/database-{env}).
+fetch_smoke_admin_creds() {
+  if [[ -n "${SMOKE_ADMIN_EMAIL:-}" && -n "${SMOKE_ADMIN_PASSWORD:-}" ]]; then
+    log_info "Using SMOKE_ADMIN_EMAIL/PASSWORD from environment."
+    return 0
+  fi
+
+  log_info "SMOKE_ADMIN_EMAIL not set — checking Secrets Manager ($SECRETS_ID)..."
+
+  local secret_json
+  if ! secret_json=$(aws_cmd secretsmanager get-secret-value \
+    --secret-id "$SECRETS_ID" \
+    --query 'SecretString' \
+    --output text 2>&1); then
+    log_warn "Could not reach Secrets Manager — admin smoke check will be skipped."
+    return 0
+  fi
+
+  local email password
+  email=$(echo "$secret_json" | python3 -c \
+    "import json,sys; o=json.load(sys.stdin); print(o.get('SMOKE_ADMIN_EMAIL',''))" 2>/dev/null || true)
+  password=$(echo "$secret_json" | python3 -c \
+    "import json,sys; o=json.load(sys.stdin); print(o.get('SMOKE_ADMIN_PASSWORD',''))" 2>/dev/null || true)
+
+  if [[ -n "$email" && -n "$password" ]]; then
+    export SMOKE_ADMIN_EMAIL="$email"
+    export SMOKE_ADMIN_PASSWORD="$password"
+    log_success "Admin smoke creds loaded from Secrets Manager."
+  else
+    log_warn "SMOKE_ADMIN_EMAIL/PASSWORD not found in $SECRETS_ID — admin smoke check will be skipped."
+    log_warn "To enable: add keys SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD to the secret, or export them before running this script."
+  fi
+}
+
 phase7_smoke() {
-  "$PROJECT_ROOT/scripts/api-smoke.sh" --env "$IN_ENV"
+  # Forward SMOKE_TEST_PHONE from the loaded environment (dev.env defines it
+  # as a magic-prefix number; prod leaves it unset — set it manually for prod).
+  fetch_smoke_admin_creds
+
+  SMOKE_TEST_PHONE="${SMOKE_TEST_PHONE:-}" \
+  SMOKE_ADMIN_EMAIL="${SMOKE_ADMIN_EMAIL:-}" \
+  SMOKE_ADMIN_PASSWORD="${SMOKE_ADMIN_PASSWORD:-}" \
+    "$PROJECT_ROOT/scripts/api-smoke.sh" --env "$IN_ENV"
 }
 
 # --------------------------------------------------------------------------

--- a/scripts/closeout-test.sh
+++ b/scripts/closeout-test.sh
@@ -1,0 +1,529 @@
+#!/bin/bash
+set -uo pipefail
+
+# closeout-test.sh — CODEX track closeout test suite
+#
+# Runs all test phases (Jest → Flutter → local E2E → [sanity gate] →
+# migrate → deploy → AWS E2E → smoke) and writes a timestamped log to
+# test_logs/. Use --local-only to skip the sanity gate and all AWS phases.
+#
+# Usage:
+#   ./scripts/closeout-test.sh TRACK_ID [--env dev|prod] [--local-only]
+#   ./scripts/closeout-test.sh --help
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+source "$SCRIPT_DIR/coop/config.sh"
+
+# --------------------------------------------------------------------------
+# Phase registry (indexed array — bash 3.2 compatible)
+# --------------------------------------------------------------------------
+PHASE_NAMES=(
+  ""                             # [0] unused
+  "Jest unit tests"              # [1]
+  "Flutter widget tests"         # [2]
+  "Local E2E (localhost:3000)"   # [3]
+  "DB migration"                 # [4]
+  "API deploy"                   # [5]
+  "AWS E2E"                      # [6]
+  "Smoke test"                   # [7]
+)
+
+# Results: PASS | FAIL | SKIP | NOT_RUN (empty = NOT_RUN)
+RESULTS=("" "" "" "" "" "" "" "")
+
+OVERALL_FAIL=false
+LOCAL_ONLY=false
+LOG_FILE=""
+LOCAL_API_PID=""
+
+# --------------------------------------------------------------------------
+# Usage
+# --------------------------------------------------------------------------
+print_usage() {
+  # Use $'...' syntax so actual ESC chars are embedded in the heredoc
+  local B=$'\033[1m' N=$'\033[0m'
+  cat <<EOF
+${B}closeout-test.sh${N} — CODEX track closeout test suite
+
+${B}USAGE${N}
+  ./scripts/closeout-test.sh TRACK_ID [options]
+
+${B}ARGUMENTS${N}
+  TRACK_ID            Identifies this run (e.g. A0-mopup, B1-feature).
+                      Used in the log filename written to test_logs/.
+
+${B}OPTIONS${N}
+  --env dev|prod      Target AWS environment for phases 4–7 (default: dev)
+  --local-only        Run only local phases (1–3). Skips the sanity gate
+                      and all AWS operations (migration, deploy, E2E, smoke).
+                      Safe to run without AWS credentials or infra running.
+  --help, -h          Show this help message
+
+${B}PHASES${N}
+  [1]  Jest unit tests      npm test — testcontainer PG, no network required
+  [2]  Flutter tests        flutter test — social-app then admin-app
+  [3]  Local E2E            E2E suite → http://localhost:3000
+                            Spins up postgres:16 in Docker, runs migrations,
+                            starts the API against it, runs E2E, tears down.
+                            Requires: Docker Desktop running. No AWS needed.
+
+  ─── SANITY GATE — operator must confirm before AWS operations ──────────
+  (Gate and phases 4–7 are skipped entirely with --local-only)
+
+  [4]  DB migration    node scripts/migrate.js
+                      DB_PASSWORD auto-fetched from Secrets Manager if not set.
+  [5]  API deploy      ./scripts/deploy-api.sh --env <env>
+  [6]  AWS E2E         E2E suite → https://<env>-api.industrynight.net
+  [7]  Smoke test      ./scripts/api-smoke.sh --env <env>
+
+${B}LOG OUTPUT${N}
+  test_logs/TRACK_ID_closeout_test_YYYY-MM-DD_HHMMSS.log
+  (test_logs/ is git-ignored — logs do not pollute the repo)
+
+${B}EXAMPLES${N}
+  # Full run — DB_PASSWORD auto-fetched from Secrets Manager
+  ./scripts/closeout-test.sh A0-mopup
+
+  # Full run — override DB password explicitly
+  DB_PASSWORD=xxx ./scripts/closeout-test.sh A0-mopup
+
+  # Local phases only — no AWS, no credentials needed
+  ./scripts/closeout-test.sh A0-mopup --local-only
+
+  # Full run targeting prod
+  DB_PASSWORD=xxx ./scripts/closeout-test.sh B1-feature --env prod
+
+  # Local only (--env is accepted but ignored in local-only mode)
+  ./scripts/closeout-test.sh B1-feature --local-only --env prod
+EOF
+}
+
+# --------------------------------------------------------------------------
+# Argument parsing
+# --------------------------------------------------------------------------
+TRACK_ID=""
+ENV_ARGS=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help|-h)
+      print_usage; exit 0 ;;
+    --local-only)
+      LOCAL_ONLY=true; shift ;;
+    --env)
+      [[ $# -lt 2 ]] && { log_error "--env requires a value (dev|prod)"; exit 1; }
+      ENV_ARGS+=("$1" "$2"); shift 2 ;;
+    -*)
+      log_error "Unknown option: $1"
+      echo ""
+      print_usage
+      exit 1 ;;
+    *)
+      if [[ -z "$TRACK_ID" ]]; then
+        TRACK_ID="$1"; shift
+      else
+        log_error "Unexpected argument: $1 (TRACK_ID already set to '$TRACK_ID')"
+        exit 1
+      fi ;;
+  esac
+done
+
+if [[ -z "$TRACK_ID" ]]; then
+  log_error "TRACK_ID is required."
+  echo ""
+  print_usage
+  exit 1
+fi
+
+# Resolve environment (always parse so IN_ENV is set; only load AWS env when needed)
+parse_env_flag "${ENV_ARGS[@]+"${ENV_ARGS[@]}"}"
+if [[ "$LOCAL_ONLY" == false ]]; then
+  load_environment "$IN_ENV"
+fi
+
+TOTAL_PHASES=7
+if [[ "$LOCAL_ONLY" == true ]]; then
+  TOTAL_PHASES=3
+fi
+
+# --------------------------------------------------------------------------
+# Log file setup — tee all stdout/stderr to timestamped file
+# --------------------------------------------------------------------------
+TIMESTAMP="$(date +%Y-%m-%d_%H%M%S)"
+LOG_DIR="$PROJECT_ROOT/test_logs"
+mkdir -p "$LOG_DIR"
+LOG_FILE="$LOG_DIR/${TRACK_ID}_closeout_test_${TIMESTAMP}.log"
+
+echo -e "${CYAN}[INFO]${NC} Log → $LOG_FILE" >/dev/tty
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# --------------------------------------------------------------------------
+# Trap: print summary on Ctrl-C
+# --------------------------------------------------------------------------
+cleanup() {
+  if [[ -n "$LOCAL_API_PID" ]]; then
+    kill "$LOCAL_API_PID" 2>/dev/null || true
+    LOCAL_API_PID=""
+  fi
+}
+trap 'echo ""; log_warn "Interrupted — partial results below."; cleanup; print_summary; exit 130' INT
+trap 'cleanup' EXIT
+
+# --------------------------------------------------------------------------
+# Header / Summary helpers
+# --------------------------------------------------------------------------
+print_banner() {
+  local title=$1
+  echo ""
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+  echo -e "${BOLD}  $title${NC}"
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+}
+
+print_header() {
+  local git_branch git_sha
+  git_branch="$(git -C "$PROJECT_ROOT" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")"
+  git_sha="$(git -C "$PROJECT_ROOT" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+
+  print_banner "CODEX CLOSEOUT — $TRACK_ID"
+  echo "  Date:    $(date '+%Y-%m-%d %H:%M:%S %Z')"
+  echo "  Branch:  $git_branch @ $git_sha"
+  if [[ "$LOCAL_ONLY" == true ]]; then
+    echo "  Mode:    local-only (phases 1–3)"
+  else
+    echo "  Mode:    full (phases 1–7, env: $IN_ENV)"
+  fi
+  echo "  Log:     $LOG_FILE"
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+  echo ""
+}
+
+result_line() {
+  local num=$1
+  local result="${RESULTS[$num]:-NOT_RUN}"
+  local label="${PHASE_NAMES[$num]}"
+  case "$result" in
+    PASS)    echo -e "  [${GREEN}PASS${NC}]  Phase $num — $label" ;;
+    FAIL)    echo -e "  [${RED}FAIL${NC}]  Phase $num — $label" ;;
+    SKIP)    echo -e "  [${YELLOW}SKIP${NC}]  Phase $num — $label" ;;
+    NOT_RUN) echo -e "  [${YELLOW}----${NC}]  Phase $num — $label (not run)" ;;
+    *)       echo -e "  [${YELLOW}----${NC}]  Phase $num — $label" ;;
+  esac
+}
+
+print_summary() {
+  print_banner "CLOSEOUT SUMMARY — $TRACK_ID"
+  local i
+  for i in $(seq 1 "$TOTAL_PHASES"); do
+    result_line "$i"
+  done
+  echo ""
+  if [[ "$OVERALL_FAIL" == true ]]; then
+    echo -e "  ${RED}${BOLD}RESULT: FAIL${NC} — review phase failures above."
+  else
+    echo -e "  ${GREEN}${BOLD}RESULT: PASS${NC} — all phases completed."
+  fi
+  echo ""
+  echo "  Log: $LOG_FILE"
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+  echo ""
+}
+
+# --------------------------------------------------------------------------
+# Phase runner helper
+# --------------------------------------------------------------------------
+run_phase() {
+  local num=$1 name=$2
+  shift 2
+  echo ""
+  log_step "$num" "$TOTAL_PHASES" "$name"
+  if "$@"; then
+    RESULTS[$num]="PASS"
+    log_success "Phase $num passed."
+    return 0
+  else
+    RESULTS[$num]="FAIL"
+    OVERALL_FAIL=true
+    log_error "Phase $num FAILED."
+    return 1
+  fi
+}
+
+# --------------------------------------------------------------------------
+# Phase implementations
+# --------------------------------------------------------------------------
+phase1_jest() {
+  cd "$PROJECT_ROOT/packages/api"
+  npm test
+}
+
+phase2_flutter() {
+  local failed=false
+
+  log_info "social-app →"
+  if ! (cd "$PROJECT_ROOT/packages/social-app" && flutter test); then
+    failed=true
+  fi
+
+  echo ""
+  log_info "admin-app →"
+  if ! (cd "$PROJECT_ROOT/packages/admin-app" && flutter test); then
+    failed=true
+  fi
+
+  [[ "$failed" == false ]]
+}
+
+phase3_local_e2e() {
+  echo ""
+  log_step 3 "$TOTAL_PHASES" "${PHASE_NAMES[3]}"
+
+  # ── Pre-flight: docker required ─────────────────────────────────────────
+  if ! command -v docker >/dev/null 2>&1; then
+    log_warn "docker not found — phase 3 skipped (install Docker Desktop to enable)."
+    RESULTS[3]="SKIP"
+    return 0
+  fi
+
+  # ── Pick a free port for postgres ────────────────────────────────────────
+  local pg_port
+  pg_port=$(python3 -c "
+import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.close()
+")
+  local pg_password="closeout_test_pw"
+  local pg_container="closeout-pg-$$"
+  local api_log
+  api_log="$(mktemp /tmp/closeout-api-XXXXXX.log)"
+
+  # ── Cleanup helper (called on early return) ───────────────────────────────
+  local_e2e_cleanup() {
+    if [[ -n "$LOCAL_API_PID" ]]; then
+      kill "$LOCAL_API_PID" 2>/dev/null || true
+      LOCAL_API_PID=""
+    fi
+    docker rm -f "$pg_container" >/dev/null 2>&1 || true
+    rm -f "$api_log"
+  }
+
+  # ── Start postgres:16 container ──────────────────────────────────────────
+  log_info "Starting postgres:16 container on port $pg_port..."
+  if ! docker run -d \
+    --name "$pg_container" \
+    -e POSTGRES_PASSWORD="$pg_password" \
+    -e POSTGRES_DB=industrynight \
+    -e POSTGRES_USER=postgres \
+    -p "${pg_port}:5432" \
+    postgres:16 >/dev/null; then
+    log_error "Failed to start postgres container — phase 3 skipped."
+    RESULTS[3]="SKIP"
+    rm -f "$api_log"
+    return 0
+  fi
+
+  # Wait for postgres to accept connections
+  log_info "Waiting for postgres to be ready..."
+  local pg_ready=false
+  for _ in $(seq 1 20); do
+    if docker exec "$pg_container" pg_isready -U postgres >/dev/null 2>&1; then
+      pg_ready=true; break
+    fi
+    sleep 1
+  done
+  if [[ "$pg_ready" == false ]]; then
+    log_error "Postgres did not become ready — phase 3 skipped."
+    local_e2e_cleanup
+    RESULTS[3]="SKIP"
+    return 0
+  fi
+  log_success "Postgres ready."
+
+  # ── Run migrations against local container ───────────────────────────────
+  log_info "Running migrations against local container..."
+  if ! (cd "$PROJECT_ROOT" && \
+      DB_HOST=localhost \
+      DB_PORT="$pg_port" \
+      DB_USER=postgres \
+      DB_NAME=industrynight \
+      DB_PASSWORD="$pg_password" \
+      DB_SSL=false \
+      node scripts/migrate.js --skip-k8s); then
+    log_error "Migration failed — phase 3 skipped."
+    local_e2e_cleanup
+    RESULTS[3]="SKIP"
+    return 0
+  fi
+  log_success "Migrations applied."
+
+  # ── Start API against local container ────────────────────────────────────
+  log_info "Starting local API against local postgres..."
+  (cd "$PROJECT_ROOT/packages/api" && \
+    DB_HOST=localhost \
+    DB_PORT="$pg_port" \
+    DB_USER=postgres \
+    DB_NAME=industrynight \
+    DB_PASSWORD="$pg_password" \
+    DB_SSL=false \
+    ENABLE_MAGIC_TEST_PREFIX=true \
+    JWT_SECRET=closeout-test-jwt-secret-32-chars-ok \
+    npm run dev >"$api_log" 2>&1) &
+  LOCAL_API_PID=$!
+
+  # Wait up to 90s for health (ts-node-dev cold compile ~30-45s)
+  local max_wait=90 waited=0
+  printf "[INFO] Waiting for API to become healthy "
+  while ! curl -sf http://localhost:3000/health >/dev/null 2>&1; do
+    if ! kill -0 "$LOCAL_API_PID" 2>/dev/null; then
+      echo ""
+      log_error "API process exited unexpectedly. Last startup output:"
+      tail -20 "$api_log" | sed 's/^/    /'
+      local_e2e_cleanup
+      RESULTS[3]="SKIP"
+      return 0
+    fi
+    if [[ $waited -ge $max_wait ]]; then
+      echo ""
+      log_error "API did not start within ${max_wait}s — phase 3 skipped."
+      log_error "Last startup output:"
+      tail -20 "$api_log" | sed 's/^/    /'
+      local_e2e_cleanup
+      RESULTS[3]="SKIP"
+      return 0
+    fi
+    sleep 5
+    waited=$(( waited + 5 ))
+    printf "."
+  done
+  echo ""
+  log_success "API ready (${waited}s)."
+
+  # ── Run E2E ──────────────────────────────────────────────────────────────
+  local e2e_exit=0
+  (cd "$PROJECT_ROOT/packages/api" && \
+    API_BASE_URL=http://localhost:3000 npm run test:e2e) || e2e_exit=$?
+
+  local_e2e_cleanup
+
+  if [[ $e2e_exit -eq 0 ]]; then
+    RESULTS[3]="PASS"
+    log_success "Phase 3 passed."
+  else
+    RESULTS[3]="FAIL"
+    OVERALL_FAIL=true
+    log_error "Phase 3 FAILED."
+  fi
+}
+
+sanity_gate() {
+  echo ""
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+  echo -e "${BOLD}  SANITY GATE — review local results before AWS ops${NC}"
+  echo -e "${BOLD}══════════════════════════════════════════════════${NC}"
+  echo ""
+  result_line 1
+  result_line 2
+  result_line 3
+  echo ""
+
+  if [[ "$OVERALL_FAIL" == true ]]; then
+    echo -e "  ${YELLOW}${BOLD}WARNING:${NC} One or more local phases failed."
+    echo "           Proceeding to AWS operations is NOT recommended."
+    echo ""
+  fi
+
+  printf "${BOLD}  Proceed with AWS operations (%s)? [y/N]: ${NC}" "$IN_ENV"
+  local confirm
+  read -r confirm </dev/tty
+  echo "$confirm"  # record operator choice in log
+
+  if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+    log_warn "AWS phases declined by operator."
+    for i in 4 5 6 7; do
+      RESULTS[$i]="SKIP"
+    done
+    print_summary
+    exit 0
+  fi
+
+  echo ""
+  log_info "AWS phases confirmed — proceeding."
+}
+
+# Fetch DB_PASSWORD from Secrets Manager if not already in environment.
+fetch_db_password() {
+  if [[ -n "${DB_PASSWORD:-}" ]]; then
+    log_info "Using DB_PASSWORD from environment."
+    return 0
+  fi
+
+  log_info "DB_PASSWORD not set — fetching from Secrets Manager ($SECRETS_ID)..."
+
+  local secret_json
+  if ! secret_json=$(aws_cmd secretsmanager get-secret-value \
+    --secret-id "$SECRETS_ID" \
+    --query 'SecretString' \
+    --output text 2>&1); then
+    log_error "Failed to fetch from Secrets Manager: $secret_json"
+    log_error "Set DB_PASSWORD manually: DB_PASSWORD=xxx ./scripts/closeout-test.sh $TRACK_ID --env $IN_ENV"
+    return 1
+  fi
+
+  DB_PASSWORD=$(echo "$secret_json" | python3 -c \
+    "import json,sys; o=json.load(sys.stdin); print(o.get('password') or o.get('DB_PASSWORD') or o.get('db_password') or '')")
+
+  if [[ -z "$DB_PASSWORD" ]]; then
+    log_error "Password key not found in secret $SECRETS_ID"
+    return 1
+  fi
+
+  export DB_PASSWORD
+  log_success "DB_PASSWORD loaded from Secrets Manager."
+}
+
+phase4_migrate() {
+  fetch_db_password || return 1
+  cd "$PROJECT_ROOT"
+  DB_PASSWORD="$DB_PASSWORD" node scripts/migrate.js
+}
+
+phase5_deploy() {
+  "$PROJECT_ROOT/scripts/deploy-api.sh" --env "$IN_ENV"
+}
+
+phase6_aws_e2e() {
+  local aws_url="https://${API_HOST}"
+  log_info "Target: $aws_url"
+  cd "$PROJECT_ROOT/packages/api"
+  API_BASE_URL="$aws_url" npm run test:e2e
+}
+
+phase7_smoke() {
+  "$PROJECT_ROOT/scripts/api-smoke.sh" --env "$IN_ENV"
+}
+
+# --------------------------------------------------------------------------
+# Main
+# --------------------------------------------------------------------------
+print_header
+
+run_phase 1 "${PHASE_NAMES[1]}" phase1_jest    || true
+run_phase 2 "${PHASE_NAMES[2]}" phase2_flutter || true
+phase3_local_e2e  # handles its own SKIP/PASS/FAIL and log_step internally
+
+if [[ "$LOCAL_ONLY" == true ]]; then
+  print_summary
+  if [[ "$OVERALL_FAIL" == true ]]; then exit 1; fi
+  exit 0
+fi
+
+sanity_gate
+
+run_phase 4 "${PHASE_NAMES[4]}" phase4_migrate || true
+run_phase 5 "${PHASE_NAMES[5]}" phase5_deploy  || true
+run_phase 6 "${PHASE_NAMES[6]}" phase6_aws_e2e || true
+run_phase 7 "${PHASE_NAMES[7]}" phase7_smoke   || true
+
+print_summary
+if [[ "$OVERALL_FAIL" == true ]]; then exit 1; fi
+exit 0

--- a/scripts/closeout-test.sh
+++ b/scripts/closeout-test.sh
@@ -311,7 +311,19 @@ import socket; s=socket.socket(); s.bind(('',0)); print(s.getsockname()[1]); s.c
   local pg_password="closeout_test_pw"
   local pg_container="closeout-pg-$$"
   local api_log
-  api_log="$(mktemp /tmp/closeout-api-XXXXXX.log)"
+
+  # macOS mktemp requires X's at the end of the template (no suffix after
+  # them). We previously used XXXXXX.log which macOS treated as a literal
+  # filename, leaving a stale file that caused "File exists" on next run.
+  # Drop the .log extension — the temp file is a log regardless of extension.
+  # Also remove the known stale literal name that the previous buggy call
+  # would have created, so a crashed previous run can't block us.
+  rm -f /tmp/closeout-api-XXXXXX.log 2>/dev/null || true
+  api_log="$(mktemp /tmp/closeout-api-XXXXXX)" || {
+    log_error "mktemp failed — cannot create API log file. Phase 3 skipped."
+    RESULTS[3]="SKIP"
+    return 0
+  }
 
   # ── Cleanup helper (called on early return) ───────────────────────────────
   local_e2e_cleanup() {

--- a/scripts/coop/config.sh
+++ b/scripts/coop/config.sh
@@ -286,6 +286,7 @@ apply_k8s_manifest() {
       -e "s|__ENVIRONMENT__|${ENV_LABEL}|g" \
       -e "s|__HPA_MIN__|${K8S_HPA_MIN}|g" \
       -e "s|__HPA_MAX__|${K8S_HPA_MAX}|g" \
+      -e "s|__ENABLE_MAGIC_TEST_PREFIX__|${ENABLE_MAGIC_TEST_PREFIX}|g" \
       -e "s|\${AWS_ACCOUNT_ID}|${AWS_ACCOUNT}|g" \
       "$PROJECT_ROOT/$K8S_MANIFESTS_DIR/$file" | kube_cmd apply -f -
 }

--- a/scripts/coop/environments/dev.env
+++ b/scripts/coop/environments/dev.env
@@ -50,3 +50,6 @@ BACKUPS_SUBDIR="dev"
 
 # ---- CloudWatch Logging ----
 CW_LOG_TYPES="api,audit"
+
+# ---- Feature Flags ----
+ENABLE_MAGIC_TEST_PREFIX="true"

--- a/scripts/coop/environments/dev.env
+++ b/scripts/coop/environments/dev.env
@@ -53,3 +53,7 @@ CW_LOG_TYPES="api,audit"
 
 # ---- Feature Flags ----
 ENABLE_MAGIC_TEST_PREFIX="true"
+
+# ---- Smoke Test ----
+# Magic-prefix phone for dev smoke check (no Twilio needed — ENABLE_MAGIC_TEST_PREFIX is true in dev)
+SMOKE_TEST_PHONE="+15555550199"

--- a/scripts/coop/environments/prod.env
+++ b/scripts/coop/environments/prod.env
@@ -50,3 +50,6 @@ BACKUPS_SUBDIR="prod"
 
 # ---- CloudWatch Logging ----
 CW_LOG_TYPES="api,audit,authenticator,controllerManager,scheduler"
+
+# ---- Feature Flags ----
+ENABLE_MAGIC_TEST_PREFIX="false"

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -58,7 +58,7 @@ const DB_CONFIG = {
   database: process.env.DB_NAME     || 'industrynight',
   user:     process.env.DB_USER     || 'industrynight',
   password: process.env.DB_PASSWORD,
-  ssl: { rejectUnauthorized: false },
+  ssl: process.env.DB_SSL === 'false' ? false : { rejectUnauthorized: false },
 };
 
 const NAMESPACE      = process.env.IN_NAMESPACE   || 'industrynight';

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -9,9 +9,19 @@
  * PREREQUISITES:
  *   - kubectl port-forward active (or --skip-k8s with local PG)
  *   - DB_PASSWORD env var set (or local PG with no password)
+ *
+ * After creating the admin user, the email + password are automatically
+ * saved to Secrets Manager under the SMOKE_ADMIN_EMAIL and
+ * SMOKE_ADMIN_PASSWORD keys. This keeps the closeout smoke test in sync
+ * across fresh environments without any manual follow-up.
+ *
+ * The Secrets Manager secret is chosen by IN_ENV (dev → industrynight/database-dev,
+ * prod → industrynight/database). Set IN_ENV before running for prod, or let
+ * it default to dev. Use --skip-secrets to opt out entirely.
  */
 
 const path = require('path');
+const { execSync } = require('child_process');
 const { Pool } = require(require.resolve('pg', { paths: [path.resolve(__dirname, '../packages/api')] }));
 const bcrypt = require(require.resolve('bcryptjs', { paths: [path.resolve(__dirname, '../packages/api')] }));
 
@@ -27,16 +37,48 @@ const email = getArg('email');
 const name = getArg('name');
 const password = getArg('password');
 const skipK8s = args.includes('--skip-k8s');
+const skipSecrets = args.includes('--skip-secrets');
 
 if (!email || !name || !password) {
-  console.error('Usage: node scripts/seed-admin.js --email <email> --name <name> --password <password> [--skip-k8s]');
+  console.error('Usage: node scripts/seed-admin.js --email <email> --name <name> --password <password> [--skip-k8s] [--skip-secrets]');
   console.error('');
   console.error('Options:');
-  console.error('  --email       Admin email address');
-  console.error('  --name        Admin display name');
-  console.error('  --password    Admin password (min 8 characters)');
-  console.error('  --skip-k8s    Skip kubectl port-forward (for local PG)');
+  console.error('  --email          Admin email address');
+  console.error('  --name           Admin display name');
+  console.error('  --password       Admin password (min 8 characters)');
+  console.error('  --skip-k8s       Skip kubectl port-forward (for local PG)');
+  console.error('  --skip-secrets   Skip Secrets Manager update (local dev without AWS)');
   process.exit(1);
+}
+
+/**
+ * Write SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD into the Secrets Manager
+ * secret for the current environment. Best-effort — warns on failure.
+ */
+async function syncSecretsManager(adminEmail, adminPassword) {
+  const env = process.env.IN_ENV || 'dev';
+  const secretId = env === 'prod' ? 'industrynight/database' : 'industrynight/database-dev';
+  const awsProfile = process.env.IN_AWS_PROFILE || 'industrynight-admin';
+
+  try {
+    console.log(`Syncing smoke credentials to Secrets Manager (${secretId})...`);
+    const raw = execSync(
+      `aws secretsmanager get-secret-value --secret-id '${secretId}' --query SecretString --output text --profile '${awsProfile}'`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    const current = JSON.parse(raw);
+    current.SMOKE_ADMIN_EMAIL = adminEmail;
+    current.SMOKE_ADMIN_PASSWORD = adminPassword;
+    execSync(
+      `aws secretsmanager update-secret --secret-id '${secretId}' --secret-string '${JSON.stringify(current).replace(/'/g, "'\"'\"'")}' --profile '${awsProfile}'`,
+      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
+    );
+    console.log('  Smoke credentials saved to Secrets Manager.');
+  } catch (err) {
+    console.warn(`[WARN] Could not update Secrets Manager — smoke test creds may be stale.`);
+    console.warn(`[WARN] ${err.message.split('\n')[0]}`);
+    console.warn(`[WARN] Re-run manually: aws secretsmanager update-secret --secret-id '${secretId}' ...`);
+  }
 }
 
 if (password.length < 8) {
@@ -78,6 +120,9 @@ async function main() {
     console.log(`  Name:  ${admin.name}`);
     console.log(`  Role:  ${admin.role}`);
     console.log('');
+    if (!skipSecrets) {
+      await syncSecretsManager(admin.email, password);
+    }
     console.log('Done.');
   } catch (error) {
     console.error('Error creating admin user:', error.message);

--- a/scripts/seed-admin.js
+++ b/scripts/seed-admin.js
@@ -9,19 +9,9 @@
  * PREREQUISITES:
  *   - kubectl port-forward active (or --skip-k8s with local PG)
  *   - DB_PASSWORD env var set (or local PG with no password)
- *
- * After creating the admin user, the email + password are automatically
- * saved to Secrets Manager under the SMOKE_ADMIN_EMAIL and
- * SMOKE_ADMIN_PASSWORD keys. This keeps the closeout smoke test in sync
- * across fresh environments without any manual follow-up.
- *
- * The Secrets Manager secret is chosen by IN_ENV (dev → industrynight/database-dev,
- * prod → industrynight/database). Set IN_ENV before running for prod, or let
- * it default to dev. Use --skip-secrets to opt out entirely.
  */
 
 const path = require('path');
-const { execSync } = require('child_process');
 const { Pool } = require(require.resolve('pg', { paths: [path.resolve(__dirname, '../packages/api')] }));
 const bcrypt = require(require.resolve('bcryptjs', { paths: [path.resolve(__dirname, '../packages/api')] }));
 
@@ -37,48 +27,16 @@ const email = getArg('email');
 const name = getArg('name');
 const password = getArg('password');
 const skipK8s = args.includes('--skip-k8s');
-const skipSecrets = args.includes('--skip-secrets');
 
 if (!email || !name || !password) {
-  console.error('Usage: node scripts/seed-admin.js --email <email> --name <name> --password <password> [--skip-k8s] [--skip-secrets]');
+  console.error('Usage: node scripts/seed-admin.js --email <email> --name <name> --password <password> [--skip-k8s]');
   console.error('');
   console.error('Options:');
-  console.error('  --email          Admin email address');
-  console.error('  --name           Admin display name');
-  console.error('  --password       Admin password (min 8 characters)');
-  console.error('  --skip-k8s       Skip kubectl port-forward (for local PG)');
-  console.error('  --skip-secrets   Skip Secrets Manager update (local dev without AWS)');
+  console.error('  --email       Admin email address');
+  console.error('  --name        Admin display name');
+  console.error('  --password    Admin password (min 8 characters)');
+  console.error('  --skip-k8s    Skip kubectl port-forward (for local PG)');
   process.exit(1);
-}
-
-/**
- * Write SMOKE_ADMIN_EMAIL and SMOKE_ADMIN_PASSWORD into the Secrets Manager
- * secret for the current environment. Best-effort — warns on failure.
- */
-async function syncSecretsManager(adminEmail, adminPassword) {
-  const env = process.env.IN_ENV || 'dev';
-  const secretId = env === 'prod' ? 'industrynight/database' : 'industrynight/database-dev';
-  const awsProfile = process.env.IN_AWS_PROFILE || 'industrynight-admin';
-
-  try {
-    console.log(`Syncing smoke credentials to Secrets Manager (${secretId})...`);
-    const raw = execSync(
-      `aws secretsmanager get-secret-value --secret-id '${secretId}' --query SecretString --output text --profile '${awsProfile}'`,
-      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-    );
-    const current = JSON.parse(raw);
-    current.SMOKE_ADMIN_EMAIL = adminEmail;
-    current.SMOKE_ADMIN_PASSWORD = adminPassword;
-    execSync(
-      `aws secretsmanager update-secret --secret-id '${secretId}' --secret-string '${JSON.stringify(current).replace(/'/g, "'\"'\"'")}' --profile '${awsProfile}'`,
-      { encoding: 'utf8', stdio: ['pipe', 'pipe', 'pipe'] }
-    );
-    console.log('  Smoke credentials saved to Secrets Manager.');
-  } catch (err) {
-    console.warn(`[WARN] Could not update Secrets Manager — smoke test creds may be stale.`);
-    console.warn(`[WARN] ${err.message.split('\n')[0]}`);
-    console.warn(`[WARN] Re-run manually: aws secretsmanager update-secret --secret-id '${secretId}' ...`);
-  }
 }
 
 if (password.length < 8) {
@@ -120,9 +78,6 @@ async function main() {
     console.log(`  Name:  ${admin.name}`);
     console.log(`  Role:  ${admin.role}`);
     console.log('');
-    if (!skipSecrets) {
-      await syncSecretsManager(admin.email, password);
-    }
     console.log('Done.');
   } catch (error) {
     console.error('Error creating admin user:', error.message);

--- a/scripts/seed-smoke-admin.js
+++ b/scripts/seed-smoke-admin.js
@@ -73,7 +73,7 @@ const DB_CONFIG = {
   database: process.env.DB_NAME || 'industrynight',
   user:     process.env.DB_USER || 'industrynight',
   password: process.env.DB_PASSWORD,
-  ssl: (process.env.DB_SSL === 'false' || SKIP_K8S) ? false : { rejectUnauthorized: false },
+  ssl: process.env.DB_SSL === 'false' ? false : { rejectUnauthorized: false },
 };
 
 const NAMESPACE   = process.env.IN_NAMESPACE   || 'industrynight';

--- a/scripts/seed-smoke-admin.js
+++ b/scripts/seed-smoke-admin.js
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+/**
+ * seed-smoke-admin.js — Create or delete the ephemeral smoke-test admin account
+ *
+ * Used by closeout-test.sh to provision a short-lived admin account before
+ * phase-7 smoke checks and clean it up immediately after (success or failure).
+ * The account is never left behind — it is deleted even if the smoke phase fails
+ * because closeout-test.sh wires teardown into its EXIT trap.
+ *
+ * USAGE:
+ *   node scripts/seed-smoke-admin.js --create --email <email> --password <pw> [--skip-k8s]
+ *   node scripts/seed-smoke-admin.js --delete --email <email> [--skip-k8s]
+ *
+ * ENVIRONMENT:
+ *   DB_HOST, DB_PORT, DB_NAME, DB_USER, DB_PASSWORD, DB_SSL
+ *   IN_NAMESPACE    (kubectl namespace; default: industrynight)
+ *   IN_AWS_PROFILE  (kubectl env; default: industrynight-admin)
+ */
+
+'use strict';
+
+const net  = require('net');
+const path = require('path');
+const { spawn } = require('child_process');
+
+const { Pool } = require(
+  require.resolve('pg', { paths: [path.resolve(__dirname, '../packages/api')] })
+);
+const bcrypt = require(
+  require.resolve('bcryptjs', { paths: [path.resolve(__dirname, '../packages/api')] })
+);
+
+// --------------------------------------------------------------------------
+// Arg parsing
+// --------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+
+function getArg(name) {
+  const idx = args.indexOf(`--${name}`);
+  if (idx === -1 || idx + 1 >= args.length) return null;
+  return args[idx + 1];
+}
+
+const ACTION   = args.includes('--create') ? 'create'
+               : args.includes('--delete') ? 'delete'
+               : null;
+const EMAIL    = getArg('email');
+const PASSWORD = getArg('password');
+const SKIP_K8S = args.includes('--skip-k8s');
+
+if (!ACTION || !EMAIL || (ACTION === 'create' && !PASSWORD)) {
+  console.error('Usage:');
+  console.error('  node scripts/seed-smoke-admin.js --create --email <email> --password <pw> [--skip-k8s]');
+  console.error('  node scripts/seed-smoke-admin.js --delete --email <email> [--skip-k8s]');
+  process.exit(1);
+}
+
+if (!process.env.DB_PASSWORD) {
+  console.error('ERROR: DB_PASSWORD environment variable is required.');
+  process.exit(1);
+}
+
+// --------------------------------------------------------------------------
+// DB config
+// --------------------------------------------------------------------------
+
+const DB_PORT = parseInt(process.env.DB_PORT || '5432');
+
+const DB_CONFIG = {
+  host:     process.env.DB_HOST || 'localhost',
+  port:     DB_PORT,
+  database: process.env.DB_NAME || 'industrynight',
+  user:     process.env.DB_USER || 'industrynight',
+  password: process.env.DB_PASSWORD,
+  ssl: (process.env.DB_SSL === 'false' || SKIP_K8S) ? false : { rejectUnauthorized: false },
+};
+
+const NAMESPACE   = process.env.IN_NAMESPACE   || 'industrynight';
+const AWS_PROFILE = process.env.IN_AWS_PROFILE || 'industrynight-admin';
+
+// --------------------------------------------------------------------------
+// Port-forward helpers (same pattern as migrate.js)
+// --------------------------------------------------------------------------
+
+function isPortOpen(port) {
+  return new Promise(resolve => {
+    const s = net.createConnection(port, '127.0.0.1');
+    s.on('connect', () => { s.destroy(); resolve(true); });
+    s.on('error',   () => resolve(false));
+  });
+}
+
+async function waitForPort(port, maxSeconds = 15) {
+  for (let i = 0; i < maxSeconds; i++) {
+    if (await isPortOpen(port)) return;
+    await new Promise(r => setTimeout(r, 1000));
+  }
+  throw new Error(`Port ${port} did not open within ${maxSeconds}s`);
+}
+
+let pfProcess = null;
+
+async function startPortForward() {
+  if (await isPortOpen(DB_PORT)) {
+    console.log('  Port-forward already open, using existing tunnel.');
+    return;
+  }
+  console.log('  Starting kubectl port-forward...');
+  pfProcess = spawn(
+    'kubectl',
+    ['port-forward', 'pod/db-proxy', `${DB_PORT}:5432`, '-n', NAMESPACE],
+    { env: { ...process.env, AWS_PROFILE }, stdio: 'ignore' }
+  );
+  pfProcess.on('error', err => { throw new Error(`kubectl failed: ${err.message}`); });
+  await waitForPort(DB_PORT);
+  console.log('  Tunnel ready.');
+}
+
+function stopPortForward() {
+  if (pfProcess) {
+    pfProcess.kill();
+    pfProcess = null;
+  }
+}
+
+// --------------------------------------------------------------------------
+// Main
+// --------------------------------------------------------------------------
+
+async function main() {
+  if (!SKIP_K8S) {
+    await startPortForward();
+  }
+
+  const pool = new Pool(DB_CONFIG);
+
+  try {
+    if (ACTION === 'create') {
+      const hash = await bcrypt.hash(PASSWORD, 12);
+      await pool.query(
+        `INSERT INTO admin_users (email, password_hash, name, role)
+         VALUES ($1, $2, 'Smoke Test', 'platformAdmin')
+         ON CONFLICT (email) DO UPDATE SET
+           password_hash = EXCLUDED.password_hash,
+           updated_at    = NOW()`,
+        [EMAIL.toLowerCase(), hash]
+      );
+      console.log(`  Smoke admin created: ${EMAIL}`);
+    } else {
+      const res = await pool.query(
+        'DELETE FROM admin_users WHERE email = $1 RETURNING id',
+        [EMAIL.toLowerCase()]
+      );
+      if (res.rowCount > 0) {
+        console.log(`  Smoke admin deleted: ${EMAIL}`);
+      } else {
+        console.log(`  Smoke admin not found (already deleted?): ${EMAIL}`);
+      }
+    }
+  } finally {
+    await pool.end();
+    stopPortForward();
+  }
+}
+
+main().catch(err => {
+  console.error(`seed-smoke-admin: ${err.message}`);
+  stopPortForward();
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Wraps up Track A0 integration mop-up: magic test phone prefix, a full E2E test suite against the deployed dev API, Flutter widget tests for the social app, and three schema/API bug fixes surfaced during E2E validation.

---

## Changes

### New: Magic Test Phone Prefix
- `+1555555xxxx` always routes to local devCode verification — no Twilio needed for automated tests
- Guard uses `ENABLE_MAGIC_TEST_PREFIX=true || NODE_ENV=test` (not `NODE_ENV !== 'production'` — dev k8s also sets `NODE_ENV=production`)
- Rate limiter bypassed under the same condition (avoids 429s during E2E)
- `ENABLE_MAGIC_TEST_PREFIX=true` added to dev k8s deployment via `kubectl patch`

### New: E2E Test Suite (`packages/api/tests/e2e/`)
- 25 tests against `https://dev-api.industrynight.net`
- Covers: health, specialties, full auth flow (request-code → verify-code → refresh → me → logout → delete), 401 guards, token family isolation (social token rejected on admin routes), all major social API endpoints
- Run with: `API_BASE_URL=https://dev-api.industrynight.net npm run test:e2e`

### New: Flutter Widget Tests (`packages/social-app/test/`)
- 30 tests: unit (validators), widget (phone entry, events list, community feed, connect tab)
- `test/helpers/fake_app_state.dart` — FakeAppState for widget test isolation

### Bug Fixes (surfaced by E2E)

**1. `DELETE /auth/me` → 500 on dev (migration 005)**
- Root cause: migration 002 installed an immutability trigger (`prevent_audit_log_mutation`) that raises on ANY UPDATE, including the `ON DELETE SET NULL` FK cascade PostgreSQL performs on `audit_log.actor_id` when a user is deleted. A companion CHECK constraint (`ck_audit_log_actor_identity`) required `actor_type='user' AND actor_id IS NOT NULL`, which would also be violated by plain SET NULL.
- Fix: `005_fix_audit_log_user_delete_cascade.sql` — replaces the trigger function to allow the one legitimate soft-mutation (actor_id non-null → NULL when user deleted), simultaneously promoting `actor_type` to `'system'` to satisfy the CHECK constraint.

**2. `GET /auth/me` returns 200 with `{ user: null }` after account deletion**
- Fix: added null check in route — returns 404 if user no longer exists in DB.

**3. `GET /auth/me` response shape**
- Route returns `{ user: {...} }` (not a flat object); E2E assertion corrected to `res.body.user.phone`.

---

## Test Evidence

| Suite | Result |
|-------|--------|
| Local API (testcontainers) | 167/167 ✅ |
| E2E vs dev-api.industrynight.net | 25/25 ✅ |
| Flutter widget tests | 30/30 ✅ |

---

## Deployment Notes

- Migration 005 already applied to dev DB
- `ENABLE_MAGIC_TEST_PREFIX=true` already patched into dev k8s deployment
- After merging to integration, apply migration 005 to any other environments before deploying API code
